### PR TITLE
New widgets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ app-creator/redux
 app-creator/widgets
 app-creator/utils
 app-creator/app.yaml
+app-creator/build
+app-creator/env.js

--- a/app-creator/dev/index.html
+++ b/app-creator/dev/index.html
@@ -4,16 +4,16 @@
   <head>
     <meta charset="utf-8" />
     <title>Earth Engine App Creator</title>
-    <script type="module" src="../widgets/app-root.js"></script>
     <link
       href="https://fonts.googleapis.com/css?family=Google+Sans:400,500,700"
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../style.css" />
+    <script src="../env.js"></script>
   </head>
   <body>
     <app-root></app-root>
 
-    <script src="../script.js"></script>
+    <script type="module" src="../widgets/app-root.js"></script>
   </body>
 </html>

--- a/app-creator/env.example.js
+++ b/app-creator/env.example.js
@@ -1,5 +1,6 @@
 window.process = {
   env: {
     NODE_ENV: 'development',
+    MAPS_API_KEY: 'YOUR_API_KEY',
   },
 };

--- a/app-creator/karma.conf.cjs
+++ b/app-creator/karma.conf.cjs
@@ -9,7 +9,7 @@ module.exports = (config) => {
         mocha: { ui: 'tdd' },
       },
       files: [
-        './script.js',
+        './env.js',
         {
           pattern: config.grep ? config.grep : 'widgets/**/*_test.js',
           type: 'module',

--- a/app-creator/src/redux/actions.ts
+++ b/app-creator/src/redux/actions.ts
@@ -120,8 +120,7 @@ export const setDraggingWidget = (
   return {
     type: SET_DRAGGING_WIDGET,
     payload: {
-      element: widget,
-      eventType: EventType.none,
+      draggingElement: widget,
     },
   };
 };
@@ -135,7 +134,7 @@ export const setEditingWidget = (
   return {
     type: SET_EDITING_WIDGET,
     payload: {
-      element: widget,
+      editingElement: widget,
       /**
        * If widget is null, then we want to clear the editing state.
        * This occurs when are dragging a new widget or we are removing the current widget being edited.
@@ -182,7 +181,7 @@ export const resetDraggingValues = (): ResetDraggingValuesAction => {
   return {
     type: RESET_DRAGGING_VALUES,
     payload: {
-      element: null,
+      draggingElement: null,
       eventType: EventType.none,
     },
   };

--- a/app-creator/src/redux/actions.ts
+++ b/app-creator/src/redux/actions.ts
@@ -22,8 +22,6 @@ import {
   RemoveWidget,
   UPDATE_WIDGET_META_DATA,
   UpdateWidgetMetaData,
-  UpdateWidgetRef,
-  UPDATE_WIDGET_REF,
   SetSelectedTemplate,
   SET_SELECTED_TEMPLATE,
 } from './types/actions';
@@ -59,18 +57,6 @@ export const updateWidgetMetaData = (
       value,
       id,
       attributeType,
-    },
-  };
-};
-
-/**
- * Updates widget reference.
- */
-export const updateWidgetRef = (widget: Element): UpdateWidgetRef => {
-  return {
-    type: UPDATE_WIDGET_REF,
-    payload: {
-      widgetRef: widget,
     },
   };
 };

--- a/app-creator/src/redux/actions.ts
+++ b/app-creator/src/redux/actions.ts
@@ -22,6 +22,10 @@ import {
   RemoveWidget,
   UPDATE_WIDGET_META_DATA,
   UpdateWidgetMetaData,
+  UpdateWidgetRef,
+  UPDATE_WIDGET_REF,
+  SetSelectedTemplate,
+  SET_SELECTED_TEMPLATE,
 } from './types/actions';
 import {
   DEFAULT_SHARED_ATTRIBUTES,
@@ -35,6 +39,9 @@ import { Checkbox } from '../widgets/ui-checkbox/ui-checkbox';
 import { Select } from '../widgets/ui-select/ui-select';
 import { Slider } from '../widgets/ui-slider/ui-slider';
 import { Textbox } from '../widgets/ui-textbox/ui-textbox';
+import { Chart } from '../widgets/ui-chart/ui-chart';
+import { Map } from '../widgets/ui-map/ui-map';
+import { AppCreatorStore } from './reducer';
 
 /**
  * Updates widget attributes.
@@ -52,6 +59,18 @@ export const updateWidgetMetaData = (
       value,
       id,
       attributeType,
+    },
+  };
+};
+
+/**
+ * Updates widget reference.
+ */
+export const updateWidgetRef = (widget: Element): UpdateWidgetRef => {
+  return {
+    type: UPDATE_WIDGET_REF,
+    payload: {
+      widgetRef: widget,
     },
   };
 };
@@ -141,6 +160,22 @@ export const setSelectedTab = (index: Tab): SetSelectedTabAction => {
 };
 
 /**
+ * Sets the actions-panel's selected tab to the index passed in.
+ */
+export const setSelectedTemplate = (
+  template: AppCreatorStore['template'],
+  markup: string
+): SetSelectedTemplate => {
+  return {
+    type: SET_SELECTED_TEMPLATE,
+    payload: {
+      template,
+      markup,
+    },
+  };
+};
+
+/**
  * Resets dragging values on dragend.
  */
 export const resetDraggingValues = (): ResetDraggingValuesAction => {
@@ -210,6 +245,10 @@ function getUniqueAttributes(type: string): UniqueAttributes {
       return Slider.DEFAULT_SLIDER_ATTRIBUTES;
     case WidgetType.textbox:
       return Textbox.DEFAULT_TEXTBOX_ATTRIBUTES;
+    case WidgetType.chart:
+      return Chart.DEFAULT_CHART_ATTRIBUTES;
+    case WidgetType.map:
+      return Map.DEFAULT_MAP_ATTRIBUTES;
     default:
       return {};
   }

--- a/app-creator/src/redux/reducer.ts
+++ b/app-creator/src/redux/reducer.ts
@@ -29,7 +29,8 @@ export interface WidgetMetaData {
 }
 
 export interface AppCreatorStore {
-  element: Element | null;
+  editingElement: Element | null;
+  draggingElement: Element | null;
   selectedTab: Tab;
   eventType: EventType;
   widgetIDs: { [key: string]: number };
@@ -40,7 +41,8 @@ export interface AppCreatorStore {
  * Initial state of our application.
  */
 const INITIAL_STATE: AppCreatorStore = {
-  element: null,
+  editingElement: null,
+  draggingElement: null,
   selectedTab: Tab.widgets,
   eventType: EventType.none,
   widgetIDs: {
@@ -51,6 +53,8 @@ const INITIAL_STATE: AppCreatorStore = {
     panel: 0,
     slider: 0,
     checkbox: 0,
+    chart: 0,
+    map: 0,
   },
   template: {},
 };
@@ -74,7 +78,7 @@ export const reducer: Reducer<AppCreatorStore, AppCreatorAction | AnyAction> = (
     case SET_EDITING_WIDGET:
       return {
         ...state,
-        element: action.payload.element,
+        editingElement: action.payload.editingElement,
         eventType: action.payload.eventType,
         selectedTab: action.payload.openAttributesTab
           ? Tab.attributes

--- a/app-creator/src/redux/types/actions.ts
+++ b/app-creator/src/redux/types/actions.ts
@@ -2,6 +2,7 @@
  *  @fileoverview This file contains the type interfaces for each action in our store.
  */
 import { EventType, AttributeType, Tab } from './enums';
+import { AppCreatorStore } from '../reducer';
 
 export const SET_DRAGGING_WIDGET = 'SET_DRAGGING_WIDGET';
 export const SET_EDITING_WIDGET = 'SET_EDITING_WIDGET';
@@ -13,11 +14,21 @@ export const RESET_DRAGGING_VALUES = 'RESET_DRAGGING_VALUES';
 export const ADD_WIDGET_META_DATA = 'ADD_WIDGET_META_DATA';
 export const REMOVE_WIDGET = 'REMOVE_WIDGET';
 export const UPDATE_WIDGET_META_DATA = 'UPDATE_WIDGET_META_DATA';
+export const UPDATE_WIDGET_REF = 'UPDATE_WIDGET_REF';
+export const SET_SELECTED_TEMPLATE = 'SET_SELECTED_TEMPLATE';
 
 export interface RemoveWidget {
   type: typeof REMOVE_WIDGET;
   payload: {
     id: string;
+  };
+}
+
+export interface SetSelectedTemplate {
+  type: typeof SET_SELECTED_TEMPLATE;
+  payload: {
+    template: AppCreatorStore['template'];
+    markup: string;
   };
 }
 
@@ -41,6 +52,13 @@ export interface UpdateWidgetMetaData {
     value: string;
     id: string;
     attributeType: AttributeType;
+  };
+}
+
+export interface UpdateWidgetRef {
+  type: typeof UPDATE_WIDGET_REF;
+  payload: {
+    widgetRef: Element;
   };
 }
 

--- a/app-creator/src/redux/types/actions.ts
+++ b/app-creator/src/redux/types/actions.ts
@@ -14,7 +14,6 @@ export const RESET_DRAGGING_VALUES = 'RESET_DRAGGING_VALUES';
 export const ADD_WIDGET_META_DATA = 'ADD_WIDGET_META_DATA';
 export const REMOVE_WIDGET = 'REMOVE_WIDGET';
 export const UPDATE_WIDGET_META_DATA = 'UPDATE_WIDGET_META_DATA';
-export const UPDATE_WIDGET_REF = 'UPDATE_WIDGET_REF';
 export const SET_SELECTED_TEMPLATE = 'SET_SELECTED_TEMPLATE';
 
 export interface RemoveWidget {
@@ -52,13 +51,6 @@ export interface UpdateWidgetMetaData {
     value: string;
     id: string;
     attributeType: AttributeType;
-  };
-}
-
-export interface UpdateWidgetRef {
-  type: typeof UPDATE_WIDGET_REF;
-  payload: {
-    widgetRef: Element;
   };
 }
 
@@ -124,5 +116,4 @@ export type AppCreatorAction =
   | ResetDraggingValuesAction
   | AddWidgetMetaData
   | RemoveWidget
-  | UpdateWidgetMetaData
-  | UpdateWidgetRef;
+  | UpdateWidgetMetaData;

--- a/app-creator/src/redux/types/actions.ts
+++ b/app-creator/src/redux/types/actions.ts
@@ -65,15 +65,14 @@ export interface UpdateWidgetRef {
 export interface SetDraggingWidgetAction {
   type: typeof SET_DRAGGING_WIDGET;
   payload: {
-    element: Element | null;
-    eventType: EventType;
+    draggingElement: Element | null;
   };
 }
 
 export interface SetEditingWidgetAction {
   type: typeof SET_EDITING_WIDGET;
   payload: {
-    element: Element | null;
+    editingElement: Element | null;
     eventType: EventType;
     openAttributesTab: boolean;
   };
@@ -89,7 +88,7 @@ export interface SetSelectedTabAction {
 export interface ResetDraggingValuesAction {
   type: typeof RESET_DRAGGING_VALUES;
   payload: {
-    element: null;
+    draggingElement: null;
     eventType: EventType;
   };
 }
@@ -125,4 +124,5 @@ export type AppCreatorAction =
   | ResetDraggingValuesAction
   | AddWidgetMetaData
   | RemoveWidget
-  | UpdateWidgetMetaData;
+  | UpdateWidgetMetaData
+  | UpdateWidgetRef;

--- a/app-creator/src/redux/types/attributes.ts
+++ b/app-creator/src/redux/types/attributes.ts
@@ -8,6 +8,8 @@ import { Checkbox } from '../../widgets/ui-checkbox/ui-checkbox';
 import { Select } from '../../widgets/ui-select/ui-select';
 import { Slider } from '../../widgets/ui-slider/ui-slider';
 import { Textbox } from '../../widgets/ui-textbox/ui-textbox';
+import { Chart } from '../../widgets/ui-chart/ui-chart';
+import { Map } from '../../widgets/ui-map/ui-map';
 
 export type SharedAttributes =
   | 'height'
@@ -68,7 +70,7 @@ export const sharedAttributes: AttributeMetaData = {
     type: InputType.color,
   },
   backgroundColor: {
-    value: '#FFFFFF',
+    value: '#FFFFFF00',
     type: InputType.color,
   },
   borderWidth: {
@@ -163,4 +165,6 @@ export type UniqueAttributes =
   | typeof Checkbox.DEFAULT_CHECKBOX_ATTRIBUTES
   | typeof Select.DEFAULT_SELECT_ATTRIBUTES
   | typeof Slider.DEFAULT_SLIDER_ATTRIBUTES
-  | typeof Textbox.DEFAULT_TEXTBOX_ATTRIBUTES;
+  | typeof Textbox.DEFAULT_TEXTBOX_ATTRIBUTES
+  | typeof Chart.DEFAULT_CHART_ATTRIBUTES
+  | typeof Map.DEFAULT_MAP_ATTRIBUTES;

--- a/app-creator/src/redux/types/attributes.ts
+++ b/app-creator/src/redux/types/attributes.ts
@@ -33,6 +33,7 @@ export interface AttributeMetaData {
     value: string;
     placeholder?: string;
     unit?: string;
+    step?: number;
     type: InputType;
     items?: string[];
   };

--- a/app-creator/src/redux/types/enums.ts
+++ b/app-creator/src/redux/types/enums.ts
@@ -13,6 +13,9 @@ export enum WidgetType {
   select = 'select',
   slider = 'slider',
   textbox = 'textbox',
+  panel = 'panel',
+  map = 'map',
+  chart = 'chart',
 }
 
 export enum Tab {
@@ -31,4 +34,9 @@ export enum EventType {
   reordering = 'reordering',
   adding = 'adding',
   none = 'none',
+}
+
+export enum DeviceType {
+  desktop = 'desktop',
+  mobile = 'mobile',
 }

--- a/app-creator/src/utils/helpers.ts
+++ b/app-creator/src/utils/helpers.ts
@@ -14,3 +14,8 @@ export function camelCaseToTitleCase(text: string) {
 export function getIdPrefix(id: string): string {
   return id.slice(0, id.indexOf('-'));
 }
+
+/**
+ * Empty function.
+ */
+export const noop = () => {};

--- a/app-creator/src/widgets/actions-panel/test/actions-panel_test.ts
+++ b/app-creator/src/widgets/actions-panel/test/actions-panel_test.ts
@@ -14,4 +14,9 @@ suite('actions-panel', () => {
     const el = await fixture(html`<actions-panel></actions-panel>`);
     expect(el.shadowRoot!.childNodes.length).to.be.greaterThan(0);
   });
+
+  test('renders correct tag', async () => {
+    const el = await fixture(html`<actions-panel></actions-panel>`);
+    expect(el.tagName).to.equal('ACTIONS-PANEL');
+  });
 });

--- a/app-creator/src/widgets/attributes-tab/attributes-tab.ts
+++ b/app-creator/src/widgets/attributes-tab/attributes-tab.ts
@@ -333,7 +333,7 @@ ${value}</textarea
     attributesArray: AttributeMetaData,
     uniqueAttributes: UniqueAttributes,
     id: string
-  ): (TemplateResult | {})[] {
+  ): Array<TemplateResult | {}> {
     return Object.keys(attributesArray).map((key) => {
       const value = uniqueAttributes[key];
       const placeholder = attributesArray[key].placeholder;
@@ -397,7 +397,7 @@ ${value}</textarea
     });
   }
 
-  getUniqueAttributes(): (TemplateResult | {})[] | {} {
+  getUniqueAttributes(): Array<TemplateResult | {}> | {} {
     const widget = this.editingWidget;
     if (widget == null) {
       return nothing;
@@ -462,7 +462,7 @@ ${value}</textarea
     }
   }
 
-  getStyleAttributes(): (TemplateResult | {})[] | {} {
+  getStyleAttributes(): Array<TemplateResult | {}> | {} {
     const widget = this.editingWidget;
     if (widget == null) {
       return nothing;

--- a/app-creator/src/widgets/attributes-tab/test/attributes-tab_test.ts
+++ b/app-creator/src/widgets/attributes-tab/test/attributes-tab_test.ts
@@ -19,4 +19,9 @@ suite('attributes-tab', () => {
     const el = await fixture(html`<attributes-tab></attributes-tab>`);
     expect(el.shadowRoot!.querySelector('empty-notice')).to.exist;
   });
+
+  test('renders correct tag', async () => {
+    const el = await fixture(html`<attributes-tab></attributes-tab>`);
+    expect(el.tagName).to.equal('ATTRIBUTES-TAB');
+  });
 });

--- a/app-creator/src/widgets/draggable-widget/draggable-widget.ts
+++ b/app-creator/src/widgets/draggable-widget/draggable-widget.ts
@@ -24,9 +24,11 @@ export class DraggableWidget extends LitElement {
       border: var(--light-dashed-border);
       border-radius: var(--tight);
       width: 100%;
+      min-height: 30px;
       margin: var(--extra-tight) 0px;
       position: relative;
       cursor: move;
+      overflow: hidden;
     }
 
     .overlay {
@@ -95,11 +97,6 @@ export class DraggableWidget extends LitElement {
           <div id="editable-view">
             <iron-icon
               class="edit-buttons"
-              icon="create"
-              @click=${handleEditWidget}
-            ></iron-icon>
-            <iron-icon
-              class="edit-buttons"
               icon="icons:delete"
               @click=${handleRemoveWidget}
             ></iron-icon>
@@ -112,6 +109,7 @@ export class DraggableWidget extends LitElement {
         id="container"
         draggable="true"
         style=${styleMap(styles)}
+        @click=${handleEditWidget}
         @dragstart=${handleDragstart}
         @dragend=${handleDragend}
       >

--- a/app-creator/src/widgets/draggable-widget/draggable-widget.ts
+++ b/app-creator/src/widgets/draggable-widget/draggable-widget.ts
@@ -125,8 +125,13 @@ export class DraggableWidget extends LitElement {
    */
   handleEditWidget() {
     if (!this.editable) {
+      /**
+       * Draggable widgets on the left side panel are not editable
+       * and thus we need to return early.
+       */
       return;
     }
+
     const container = this.shadowRoot?.getElementById(
       CONTAINER_ID
     ) as HTMLElement;

--- a/app-creator/src/widgets/draggable-widget/test/draggable-widget_test.ts
+++ b/app-creator/src/widgets/draggable-widget/test/draggable-widget_test.ts
@@ -14,4 +14,9 @@ suite('draggable-widget', () => {
     const el = await fixture(html`<draggable-widget></draggable-widget>`);
     expect(el.shadowRoot!.childNodes.length).to.be.greaterThan(0);
   });
+
+  test('renders correct tag', async () => {
+    const el = await fixture(html`<draggable-widget></draggable-widget>`);
+    expect(el.tagName).to.equal('DRAGGABLE-WIDGET');
+  });
 });

--- a/app-creator/src/widgets/dropzone-widget/dropzone-widget.ts
+++ b/app-creator/src/widgets/dropzone-widget/dropzone-widget.ts
@@ -133,6 +133,7 @@ export class Dropzone extends LitElement {
     if (store.getState().eventType !== EventType.adding) {
       store.dispatch(setElementAdded(true));
     }
+
     store.dispatch(addWidgetMetaData(clone.id, clone));
   }
 
@@ -147,7 +148,7 @@ export class Dropzone extends LitElement {
     }
 
     // Get widget that's currently being dragged.
-    const widget = store.getState().element;
+    const widget = store.getState().draggingElement;
 
     const widgetWrapper = widget?.parentElement;
     if (widget == null || widgetWrapper == null) {

--- a/app-creator/src/widgets/dropzone-widget/test/dropzone-widget_test.ts
+++ b/app-creator/src/widgets/dropzone-widget/test/dropzone-widget_test.ts
@@ -14,4 +14,9 @@ suite('dropzone-widget', () => {
     const el = await fixture(html`<dropzone-widget></dropzone-widget>`);
     expect(el.shadowRoot!.childNodes.length).to.be.greaterThan(0);
   });
+
+  test('renders correct tag', async () => {
+    const el = await fixture(html`<dropzone-widget></dropzone-widget>`);
+    expect(el.tagName).to.equal('DROPZONE-WIDGET');
+  });
 });

--- a/app-creator/src/widgets/empty-notice/test/empty-notice_test.ts
+++ b/app-creator/src/widgets/empty-notice/test/empty-notice_test.ts
@@ -14,4 +14,9 @@ suite('empty-notice', () => {
     const el = await fixture(html`<empty-notice></empty-notice>`);
     expect(el.shadowRoot!.childNodes.length).to.be.greaterThan(0);
   });
+
+  test('renders correct tag', async () => {
+    const el = await fixture(html`<empty-notice></empty-notice>`);
+    expect(el.tagName).to.equal('EMPTY-NOTICE');
+  });
 });

--- a/app-creator/src/widgets/search-bar/test/search-bar_test.ts
+++ b/app-creator/src/widgets/search-bar/test/search-bar_test.ts
@@ -14,4 +14,9 @@ suite('search-bar', () => {
     const el = await fixture(html`<search-bar></search-bar>`);
     expect(el.shadowRoot!.childNodes.length).to.be.greaterThan(0);
   });
+
+  test('renders correct tag', async () => {
+    const el = await fixture(html`<search-bar></search-bar>`);
+    expect(el.tagName).to.equal('SEARCH-BAR');
+  });
 });

--- a/app-creator/src/widgets/story-board/test/story-board_test.ts
+++ b/app-creator/src/widgets/story-board/test/story-board_test.ts
@@ -14,4 +14,9 @@ suite('story-board', () => {
     const el = await fixture(html`<story-board></story-board>`);
     expect(el.shadowRoot!.childNodes.length).to.be.greaterThan(0);
   });
+
+  test('renders correct tag', async () => {
+    const el = await fixture(html`<story-board></story-board>`);
+    expect(el.tagName).to.equal('STORY-BOARD');
+  });
 });

--- a/app-creator/src/widgets/tab-container/test/tab-container_test.ts
+++ b/app-creator/src/widgets/tab-container/test/tab-container_test.ts
@@ -30,4 +30,9 @@ suite('tab-container', () => {
     );
     expect(el.shadowRoot!.textContent).to.include(title);
   });
+
+  test('renders correct tag', async () => {
+    const el = await fixture(html`<tab-container></tab-container>`);
+    expect(el.tagName).to.equal('TAB-CONTAINER');
+  });
 });

--- a/app-creator/src/widgets/test/app-root_test.ts
+++ b/app-creator/src/widgets/test/app-root_test.ts
@@ -15,4 +15,9 @@ suite('app-root', () => {
     const el = await fixture(html`<app-root></app-root>`);
     expect(el.shadowRoot!.childNodes.length).to.be.greaterThan(0);
   });
+
+  test('renders correct tag', async () => {
+    const el = await fixture(html`<app-root></app-root>`);
+    expect(el.tagName).to.equal('APP-ROOT');
+  });
 });

--- a/app-creator/src/widgets/tool-bar/test/tool-bar_test.ts
+++ b/app-creator/src/widgets/tool-bar/test/tool-bar_test.ts
@@ -16,4 +16,9 @@ suite('tool-bar', () => {
     expect(el.shadowRoot!.textContent).to.include(ToolBar.prefix);
     expect(el.shadowRoot!.textContent).to.include(ToolBar.suffix);
   });
+
+  test('renders correct tag', async () => {
+    const el = await fixture(html`<tool-bar></tool-bar>`);
+    expect(el.tagName).to.equal('TOOL-BAR');
+  });
 });

--- a/app-creator/src/widgets/tool-bar/tool-bar.ts
+++ b/app-creator/src/widgets/tool-bar/tool-bar.ts
@@ -1,12 +1,12 @@
 /**
  *  @fileoverview The tool-bar widget is the header component
- *  which contains the app title and export actions.
+ *  which contains the app title and export action. It handles the logic for
+ *  displaying a serialized template string that the user can copy
+ *  and import into the code editor.
  */
 import { LitElement, html, customElement, css } from 'lit-element';
 import '@polymer/paper-button/paper-button.js';
 import { store } from '../../redux/store';
-
-// The paper dialog widget appears on export button click and is used to display the serialized template string.
 import '@polymer/paper-dialog/paper-dialog.js';
 import { PaperDialogElement } from '@polymer/paper-dialog/paper-dialog.js';
 import '@polymer/paper-dialog-scrollable/paper-dialog-scrollable.js';
@@ -76,8 +76,12 @@ export class ToolBar extends LitElement {
     }
   `;
 
+  /**
+   * Triggered when export button is clicked. It displays the paper dialog which
+   * contains the serialized template string.
+   */
   openDialog() {
-    const dialog = this.shadowRoot?.getElementById('dialog');
+    const dialog = this.shadowRoot?.querySelector('paper-dialog');
     const jsonSnippetContainer = this.shadowRoot?.getElementById(
       'json-snippet'
     );
@@ -85,14 +89,17 @@ export class ToolBar extends LitElement {
     if (dialog == null || jsonSnippetContainer == null) {
       return;
     }
-    jsonSnippetContainer.innerHTML = this.getTemplateString();
+    jsonSnippetContainer.textContent = this.getTemplateString();
 
     (dialog as PaperDialogElement).open();
   }
 
+  /**
+   * Returns the serialized template string with indentation.
+   */
   getTemplateString() {
     const template = store.getState().template;
-    // Remove widget reference from JSON.
+    // Remove all widget references from JSON.
     for (const key in template) {
       if (typeof template[key] === 'object' && !Array.isArray(template[key])) {
         delete template[key].widgetRef;
@@ -101,6 +108,9 @@ export class ToolBar extends LitElement {
     return JSON.stringify(template, undefined, 3);
   }
 
+  /**
+   * Adds template string to clipboard.
+   */
   copy() {
     const copyText = this.shadowRoot?.getElementById('json-snippet');
     if (copyText == null) {
@@ -122,7 +132,6 @@ export class ToolBar extends LitElement {
           <strong id="app-title-prefix">${ToolBar.prefix}</strong>
           <span id="app-title-suffix">${ToolBar.suffix}</span>
         </h3>
-
         <ui-button
           .raised=${false}
           id="export-button"

--- a/app-creator/src/widgets/tool-bar/tool-bar.ts
+++ b/app-creator/src/widgets/tool-bar/tool-bar.ts
@@ -4,9 +4,12 @@
  */
 import { LitElement, html, customElement, css } from 'lit-element';
 import '@polymer/paper-button/paper-button.js';
-import '@polymer/paper-dialog/paper-dialog.js';
-import '@polymer/paper-dialog-scrollable/paper-dialog-scrollable.js';
 import { store } from '../../redux/store';
+
+// The paper dialog widget appears on export button click and is used to display the serialized template string.
+import '@polymer/paper-dialog/paper-dialog.js';
+import { PaperDialogElement } from '@polymer/paper-dialog/paper-dialog.js';
+import '@polymer/paper-dialog-scrollable/paper-dialog-scrollable.js';
 
 @customElement('tool-bar')
 export class ToolBar extends LitElement {
@@ -84,11 +87,18 @@ export class ToolBar extends LitElement {
     }
     jsonSnippetContainer.innerHTML = this.getTemplateString();
 
-    (dialog as any).open();
+    (dialog as PaperDialogElement).open();
   }
 
   getTemplateString() {
-    return JSON.stringify(store.getState().template, undefined, 3);
+    const template = store.getState().template;
+    // Remove widget reference from JSON.
+    for (const key in template) {
+      if (typeof template[key] === 'object' && !Array.isArray(template[key])) {
+        delete template[key].widgetRef;
+      }
+    }
+    return JSON.stringify(template, undefined, 3);
   }
 
   copy() {

--- a/app-creator/src/widgets/tool-bar/tool-bar.ts
+++ b/app-creator/src/widgets/tool-bar/tool-bar.ts
@@ -4,6 +4,9 @@
  */
 import { LitElement, html, customElement, css } from 'lit-element';
 import '@polymer/paper-button/paper-button.js';
+import '@polymer/paper-dialog/paper-dialog.js';
+import '@polymer/paper-dialog-scrollable/paper-dialog-scrollable.js';
+import { store } from '../../redux/store';
 
 @customElement('tool-bar')
 export class ToolBar extends LitElement {
@@ -16,6 +19,7 @@ export class ToolBar extends LitElement {
       padding: var(--regular);
       display: flex;
       align-items: center;
+      justify-content: space-between;
       border-bottom: var(--light-border);
       background-color: var(--primary-color);
     }
@@ -35,15 +39,107 @@ export class ToolBar extends LitElement {
       padding: 0;
       font-size: 1rem;
     }
+
+    #dialog {
+      padding: var(--tight);
+      border-radius: var(--tight);
+      width: 40%;
+      max-height: 600px;
+    }
+
+    #json-string-container {
+      margin: 16px;
+      overflow-y: scroll;
+      overflow-x: scroll;
+      padding: 16px;
+      background-color: var(--background-color);
+      max-height: 400px;
+    }
+
+    #json-snippet {
+      font-family: monospace;
+    }
+
+    #copy-button {
+      background-color: var(--accent-color);
+    }
+
+    #cancel-button {
+      color: var(--accent-color);
+    }
+
+    paper-button {
+      margin-right: var(--tight);
+    }
   `;
 
+  openDialog() {
+    const dialog = this.shadowRoot?.getElementById('dialog');
+    const jsonSnippetContainer = this.shadowRoot?.getElementById(
+      'json-snippet'
+    );
+
+    if (dialog == null || jsonSnippetContainer == null) {
+      return;
+    }
+    jsonSnippetContainer.innerHTML = this.getTemplateString();
+
+    (dialog as any).open();
+  }
+
+  getTemplateString() {
+    return JSON.stringify(store.getState().template, undefined, 3);
+  }
+
+  copy() {
+    const copyText = this.shadowRoot?.getElementById('json-snippet');
+    if (copyText == null) {
+      return;
+    }
+    const textArea = document.createElement('textarea');
+    textArea.value = copyText.innerText;
+    document.body.appendChild(textArea);
+    textArea.select();
+    document.execCommand('Copy');
+    textArea.remove();
+  }
+
   render() {
+    const { openDialog, copy } = this;
     return html`
       <div id="container">
         <h3>
           <strong id="app-title-prefix">${ToolBar.prefix}</strong>
           <span id="app-title-suffix">${ToolBar.suffix}</span>
         </h3>
+
+        <ui-button
+          .raised=${false}
+          id="export-button"
+          label="export"
+          color="secondary"
+          @click=${openDialog}
+        ></ui-button>
+
+        <paper-dialog id="dialog">
+          <h2>Paste string in EE Code Editor</h2>
+          <paper-dialog-scrollable id="json-string-container">
+            <pre><code id="json-snippet"></code
+          ></pre>
+          </paper-dialog-scrollable>
+          <div class="buttons">
+            <paper-button id="cancel-button" dialog-dismiss
+              >Cancel</paper-button
+            >
+            <paper-button
+              id="copy-button"
+              dialog-confirm
+              autofocus
+              @click=${copy}
+              >Copy</paper-button
+            >
+          </div>
+        </paper-dialog>
       </div>
     `;
   }

--- a/app-creator/src/widgets/ui-button/test/ui-button_test.ts
+++ b/app-creator/src/widgets/ui-button/test/ui-button_test.ts
@@ -15,4 +15,9 @@ suite('ui-button', () => {
     const el = await fixture(html`<ui-button label="${label}"></ui-button>`);
     expect(el.shadowRoot!.textContent).to.include(label);
   });
+
+  test('renders correct tag', async () => {
+    const el = await fixture(html`<ui-button></ui-button>`);
+    expect(el.tagName).to.equal('UI-BUTTON');
+  });
 });

--- a/app-creator/src/widgets/ui-button/ui-button.ts
+++ b/app-creator/src/widgets/ui-button/ui-button.ts
@@ -19,6 +19,16 @@ export class Button extends LitElement {
       height: 30px;
       font-size: 0.8rem;
     }
+
+    .primary {
+      background-color: var(--primary-color) !important;
+      color: var(--accent-color) !important;
+    }
+
+    .secondary {
+      background-color: var(--accent-color) !important;
+      color: var(--primary-color) !important;
+    }
   `;
 
   static attributes: AttributeMetaData = {
@@ -59,20 +69,29 @@ export class Button extends LitElement {
   @property({ type: String }) label = '';
 
   /**
+   * Sets the theme of the button including background and text color.
+   * Options available "primary" | "secondary".
+   */
+  @property({ type: String }) color = '';
+
+  /**
    * Callback triggered on button click.
    */
   @property({ type: Object }) onClickHandler: () => void = () => {};
 
   render() {
+    const { label, color, disabled, onClickHandler, raised, styles } = this;
+
     return html`
       <paper-button
-        style=${styleMap(this.styles)}
+        style=${styleMap(styles)}
         draggable="true"
-        @click=${this.onClickHandler}
-        ?disabled=${this.disabled}
-        ?raised=${this.raised}
+        @click=${onClickHandler}
+        ?disabled=${disabled}
+        ?raised=${raised}
+        class="${color}"
       >
-        ${this.label}
+        ${label}
       </paper-button>
     `;
   }
@@ -87,6 +106,9 @@ export class Button extends LitElement {
         break;
       case 'disabled':
         this.disabled = value === 'true';
+        break;
+      case 'color':
+        this.color = value;
         break;
     }
 

--- a/app-creator/src/widgets/ui-button/ui-button.ts
+++ b/app-creator/src/widgets/ui-button/ui-button.ts
@@ -72,7 +72,7 @@ export class Button extends LitElement {
    * Sets the theme of the button including background and text color.
    * Options available "primary" | "secondary".
    */
-  @property({ type: String }) color = '';
+  @property({ type: String }) color = 'primary';
 
   /**
    * Callback triggered on button click.

--- a/app-creator/src/widgets/ui-chart/test/ui-chart_test.ts
+++ b/app-creator/src/widgets/ui-chart/test/ui-chart_test.ts
@@ -14,4 +14,9 @@ suite('ui-chart', () => {
     const el = await fixture(html`<ui-chart></ui-chart>`);
     expect(el.shadowRoot!.childNodes.length).to.be.greaterThan(0);
   });
+
+  test('renders correct tag', async () => {
+    const el = await fixture(html`<ui-chart></ui-chart>`);
+    expect(el.tagName).to.equal('UI-CHART');
+  });
 });

--- a/app-creator/src/widgets/ui-chart/test/ui-chart_test.ts
+++ b/app-creator/src/widgets/ui-chart/test/ui-chart_test.ts
@@ -1,0 +1,17 @@
+/**
+ *  @fileoverview This file tests the ui-chart widget.
+ */
+import { Chart } from '../ui-chart';
+import { fixture, html, expect, assert } from '@open-wc/testing';
+
+suite('ui-chart', () => {
+  test('is defined', () => {
+    const el = document.createElement('ui-chart');
+    assert.instanceOf(el, Chart);
+  });
+
+  test('renders widget', async () => {
+    const el = await fixture(html`<ui-chart></ui-chart>`);
+    expect(el.shadowRoot!.childNodes.length).to.be.greaterThan(0);
+  });
+});

--- a/app-creator/src/widgets/ui-chart/ui-chart.ts
+++ b/app-creator/src/widgets/ui-chart/ui-chart.ts
@@ -1,5 +1,6 @@
 /**
- *  @fileoverview The ui-chart widget allows users to add a chart element to their template.
+ *  @fileoverview The ui-chart widget allows users to add a chart element to their template. The chart
+ *  element in the App Creator is a static image that represents an actual chart element in the EE code editor.
  */
 import '@polymer/iron-label';
 import { css, customElement, html, LitElement, property } from 'lit-element';
@@ -30,9 +31,7 @@ export class Chart extends LitElement {
                {id: 'hours', label: 'Hours per Day', type: 'number'}],
         rows: [{c:[{v: 'Work'}, {v: 11}]},
                {c:[{v: 'Eat'}, {v: 2}]},
-               {c:[{v: 'Commute'}, {v: 2}]},
-               {c:[{v: 'Watch TV'}, {v:2}]},
-               {c:[{v: 'Sleep'}, {v:7, f:'7.000'}]}]
+               {c:[{v: 'Write EE code'}, {v:7, f:'7.000'}]}]
         }`,
       type: InputType.textarea,
     },

--- a/app-creator/src/widgets/ui-chart/ui-chart.ts
+++ b/app-creator/src/widgets/ui-chart/ui-chart.ts
@@ -1,0 +1,213 @@
+/**
+ *  @fileoverview The ui-chart widget allows users to add a chart element to their template.
+ */
+import '@polymer/iron-label';
+import { css, customElement, html, LitElement, property } from 'lit-element';
+import { styleMap } from 'lit-html/directives/style-map';
+import {
+  DEFAULT_SHARED_ATTRIBUTES,
+  AttributeMetaData,
+  DefaultAttributesType,
+  getDefaultAttributes,
+} from '../../redux/types/attributes';
+import { InputType } from '../../redux/types/enums';
+
+@customElement('ui-chart')
+export class Chart extends LitElement {
+  static styles = css`
+    #container {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+  `;
+
+  static attributes: AttributeMetaData = {
+    dataTable: {
+      value: '',
+      placeholder: `{
+        cols: [{id: 'task', label: 'Task', type: 'string'},
+               {id: 'hours', label: 'Hours per Day', type: 'number'}],
+        rows: [{c:[{v: 'Work'}, {v: 11}]},
+               {c:[{v: 'Eat'}, {v: 2}]},
+               {c:[{v: 'Commute'}, {v: 2}]},
+               {c:[{v: 'Watch TV'}, {v:2}]},
+               {c:[{v: 'Sleep'}, {v:7, f:'7.000'}]}]
+        }`,
+      type: InputType.textarea,
+    },
+    chartType: {
+      value: 'Scatter Chart',
+      type: InputType.select,
+      items: [
+        'Geo Chart',
+        'Scatter Chart',
+        'Column Chart',
+        'Histogram',
+        'Bar Chart',
+        'Combo Chart',
+        'Area Chart',
+        'SteppedArea Chart',
+        'Line Chart',
+        'Pie Chart',
+        'Bubble Chart',
+        'Donut Chart',
+        'Org Chart',
+        'Treemap',
+        'Table',
+        'Timeline',
+        'Gauge',
+        'Candlestick Chart',
+      ],
+    },
+    title: {
+      value: '',
+      placeholder: 'Enter title',
+      type: InputType.text,
+    },
+    color: {
+      value: '',
+      placeholder: '#ffffff, #000000, ...',
+      type: InputType.text,
+    },
+    '3D': {
+      value: 'false',
+      type: InputType.select,
+      items: ['true', 'false'],
+    },
+    downloadable: {
+      value: 'false',
+      type: InputType.select,
+      items: ['true', 'false'],
+    },
+  };
+
+  static DEFAULT_CHART_ATTRIBUTES: DefaultAttributesType = getDefaultAttributes(
+    Chart.attributes
+  );
+
+  /**
+   * Additional custom styles for the button.
+   */
+  @property({ type: Object }) styles = DEFAULT_SHARED_ATTRIBUTES;
+
+  /**
+   * A 2-D array of data or a Google Visualization DataTable literal.
+   * See: http://developers.google.com/chart/interactive/docs/reference#DataTable.
+   */
+  @property({ type: Object }) dataTable = {};
+
+  /**
+   * If set, the label turns into a link that
+   * leads to the target url.
+   */
+  @property({ type: String }) chartType = 'Scatter Chart';
+
+  /**
+   * Sets chart width.
+   */
+  @property({ type: Number }) width = 150;
+
+  /**
+   * Sets chart height.
+   */
+  @property({ type: Number }) height = 150;
+
+  /**
+   * Chart title
+   */
+  @property({ type: String }) title = '';
+
+  /**
+   * Array of color strings.
+   */
+  @property({ type: Array }) color = [];
+
+  /**
+   * Sets 3D property of the chart.
+   */
+  @property({ type: Boolean }) is3D = false;
+
+  /**
+   * Whether the chart can be downloaded as CSV, SVG, and PNG. Defaults to true.
+   */
+  @property({ type: Boolean }) downloadable = true;
+
+  /**
+   * Sets pre-defined styles for the specified type (ie. paragraph, title).
+   */
+  @property({ type: String })
+  type = 'paragraph';
+
+  render() {
+    const { styles } = this;
+
+    return html`
+      <img
+        style=${styleMap(styles)}
+        src="https://ourcodingclub.github.io/assets/img/tutorials/earth-engine/forest_barplot.png"
+        alt="chart image"
+        height="100px"
+        width="100px"
+      />
+    `;
+  }
+
+  getDataTable(): object {
+    return this.dataTable;
+  }
+
+  getWidth(): number {
+    return this.width;
+  }
+
+  getHeight(): number {
+    return this.height;
+  }
+
+  getTitle(): string {
+    return this.title;
+  }
+
+  getColor(): string[] {
+    return this.color;
+  }
+
+  getIs3D(): boolean {
+    return this.is3D;
+  }
+
+  getStyle(): object {
+    return this.styles;
+  }
+
+  setAttribute(key: string, value: any) {
+    switch (key) {
+      case 'dataTable':
+        this.dataTable = value;
+        return;
+      case 'width':
+        this.width = value;
+        return;
+      case 'height':
+        this.height = value;
+        return;
+      case 'title':
+        this.title = value;
+        return;
+      case 'color':
+        this.color = value;
+        return;
+      case 'is3D':
+        this.is3D = value;
+        return;
+      case 'downloadable':
+        this.downloadable = value;
+    }
+  }
+
+  setStyle(style: { [key: string]: string }) {
+    this.styles = style;
+    this.requestUpdate();
+  }
+}

--- a/app-creator/src/widgets/ui-checkbox/test/ui-checkbox_test.ts
+++ b/app-creator/src/widgets/ui-checkbox/test/ui-checkbox_test.ts
@@ -17,4 +17,9 @@ suite('ui-checkbox', () => {
     );
     expect(el.shadowRoot!.textContent).to.include(label);
   });
+
+  test('renders correct tag', async () => {
+    const el = await fixture(html`<ui-checkbox></ui-checkbox>`);
+    expect(el.tagName).to.equal('UI-CHECKBOX');
+  });
 });

--- a/app-creator/src/widgets/ui-label/test/ui-label_test.ts
+++ b/app-creator/src/widgets/ui-label/test/ui-label_test.ts
@@ -15,4 +15,9 @@ suite('ui-label', () => {
     const el = await fixture(html`<ui-label value="${title}"></ui-label>`);
     expect(el.shadowRoot!.textContent).to.include(title);
   });
+
+  test('renders correct tag', async () => {
+    const el = await fixture(html`<ui-label></ui-label>`);
+    expect(el.tagName).to.equal('UI-LABEL');
+  });
 });

--- a/app-creator/src/widgets/ui-map/ui-map.ts
+++ b/app-creator/src/widgets/ui-map/ui-map.ts
@@ -23,6 +23,7 @@ const callbackPromise = new Promise((r) => (window.__initGoogleMap = r));
 
 function loadGoogleMaps(apiKey: string) {
   if (!initCalled) {
+    console.log('loading maps');
     const script = document.createElement('script');
     script.src =
       'https://maps.googleapis.com/maps/api/js?' +
@@ -54,14 +55,17 @@ export class Map extends LitElement {
       cursor: pointer;
     }
   `;
+
   static attributes: AttributeMetaData = {
     latitude: {
       value: '39.930546488601294',
       placeholder: '39.9305464',
+      step: 0.000000000000000000001,
       type: InputType.number,
     },
     longitude: {
       value: '-100.825',
+      step: 0.000000000000000000001,
       placeholder: '-100.825',
       type: InputType.number,
     },
@@ -190,7 +194,7 @@ export class Map extends LitElement {
     this.initMap();
   }
 
-  getStyle() {
+  getStyle(): { [key: string]: string } {
     return this.styles;
   }
 
@@ -201,7 +205,7 @@ export class Map extends LitElement {
     this.requestUpdate();
   }
 
-  getZoom() {
+  getZoom(): number {
     return this.zoom;
   }
 
@@ -209,7 +213,7 @@ export class Map extends LitElement {
     this.zoom = value;
   }
 
-  getCenter() {
+  getCenter(): { lat: number; lng: number } {
     return this.center;
   }
 
@@ -217,7 +221,7 @@ export class Map extends LitElement {
     this.center = value;
   }
 
-  getMap() {
+  getMap(): google.maps.Map<Element> | null {
     return this.map;
   }
 

--- a/app-creator/src/widgets/ui-map/ui-map.ts
+++ b/app-creator/src/widgets/ui-map/ui-map.ts
@@ -1,18 +1,16 @@
 import {} from 'googlemaps';
 import { customElement, html, LitElement, property, css } from 'lit-element';
-import { nothing } from 'lit-html';
 import { InputType } from '../../redux/types/enums';
 import {
   AttributeMetaData,
   DefaultAttributesType,
   getDefaultAttributes,
 } from '../../redux/types/attributes';
-import { store } from '../../redux/store';
-import { updateWidgetRef, setEditingWidget } from '../../redux/actions';
 
 declare global {
   interface Window {
     __initGoogleMap: any;
+    gm_authFailure: Function;
   }
 }
 
@@ -57,6 +55,7 @@ export class Map extends LitElement {
   `;
 
   static attributes: AttributeMetaData = {
+    // Default latitude and longitude is set to Google's Mountain View office.
     latitude: {
       value: '39.930546488601294',
       placeholder: '39.9305464',
@@ -129,7 +128,11 @@ export class Map extends LitElement {
 
       this.mapOptions.center = this.center;
 
-      this.map = new google.maps.Map(this, this.mapOptions);
+      if (this.map == null) {
+        this.map = new google.maps.Map(this, this.mapOptions);
+      } else {
+        this.map.setOptions(this.mapOptions);
+      }
       this.dispatchEvent(
         new CustomEvent('google-map-ready', { detail: this.map })
       );
@@ -142,34 +145,8 @@ export class Map extends LitElement {
     return this;
   }
 
-  /**
-   * Triggered when the edit icon is clicked. Stores a reference of the selected element in the store and
-   * displays a set of inputs for editing its attributes.
-   */
-  handleEditWidget() {
-    // Check if a widgetRef has been set.
-    const ref = store.getState().template[this.id].widgetRef;
-    if (ref == null) {
-      // Set the ref to be the current element.
-      store.dispatch(updateWidgetRef(this));
-    }
-    store.dispatch(setEditingWidget(this));
-  }
-
   render() {
-    const { editable, handleEditWidget } = this;
-    const editableMarkup = editable
-      ? html`
-          <div id="editable-view">
-            <iron-icon
-              class="edit-buttons"
-              icon="create"
-              @click=${handleEditWidget}
-            ></iron-icon>
-          </div>
-        `
-      : nothing;
-    return html` ${editableMarkup}`;
+    return html``;
   }
 
   setAttribute(key: string, value: any) {

--- a/app-creator/src/widgets/ui-panel/test/ui-panel_test.ts
+++ b/app-creator/src/widgets/ui-panel/test/ui-panel_test.ts
@@ -14,4 +14,9 @@ suite('ui-panel', () => {
     const el = await fixture(html`<ui-panel></ui-panel>`);
     expect(el.shadowRoot!.childNodes.length).to.be.greaterThan(0);
   });
+
+  test('renders correct tag', async () => {
+    const el = await fixture(html`<ui-panel></ui-panel>`);
+    expect(el.tagName).to.equal('UI-PANEL');
+  });
 });

--- a/app-creator/src/widgets/ui-select/test/ui-select_test.ts
+++ b/app-creator/src/widgets/ui-select/test/ui-select_test.ts
@@ -17,4 +17,9 @@ suite('ui-select', () => {
     );
     expect(el.shadowRoot!.textContent).to.include(value);
   });
+
+  test('renders correct tag', async () => {
+    const el = await fixture(html`<ui-select></ui-select>`);
+    expect(el.tagName).to.equal('UI-SELECT');
+  });
 });

--- a/app-creator/src/widgets/ui-select/test/ui-select_test.ts
+++ b/app-creator/src/widgets/ui-select/test/ui-select_test.ts
@@ -13,10 +13,7 @@ suite('ui-select', () => {
   test('renders widget with correct value', async () => {
     const value = 'Item 1';
     const el = await fixture(
-      html`<ui-select
-        .items=${['Item 1', 'Item 2']}
-        value="${value}"
-      ></ui-select>`
+      html`<ui-select items="Item 1, Item 2" } value="${value}"></ui-select>`
     );
     expect(el.shadowRoot!.textContent).to.include(value);
   });

--- a/app-creator/src/widgets/ui-slider/test/ui-slider_test.ts
+++ b/app-creator/src/widgets/ui-slider/test/ui-slider_test.ts
@@ -14,4 +14,9 @@ suite('ui-slider', () => {
     const el = await fixture(html`<ui-slider></ui-slider>`);
     expect(el.shadowRoot!.childNodes.length).to.be.greaterThan(0);
   });
+
+  test('renders correct tag', async () => {
+    const el = await fixture(html`<ui-slider></ui-slider>`);
+    expect(el.tagName).to.equal('UI-SLIDER');
+  });
 });

--- a/app-creator/src/widgets/ui-textbox/test/ui-textbox_test.ts
+++ b/app-creator/src/widgets/ui-textbox/test/ui-textbox_test.ts
@@ -14,4 +14,9 @@ suite('ui-textbox', () => {
     const el = await fixture(html`<ui-textbox></ui-textbox>`);
     expect(el.shadowRoot!.childNodes.length).to.be.greaterThan(0);
   });
+
+  test('renders correct tag', async () => {
+    const el = await fixture(html`<ui-select></ui-select>`);
+    expect(el.tagName).to.equal('UI-SELECT');
+  });
 });

--- a/app-creator/src/widgets/ui-textbox/test/ui-textbox_test.ts
+++ b/app-creator/src/widgets/ui-textbox/test/ui-textbox_test.ts
@@ -2,7 +2,7 @@
  *  @fileoverview This file tests the ui-textbox widget.
  */
 import { Textbox } from '../ui-textbox';
-import { fixture, html, assert } from '@open-wc/testing';
+import { fixture, html, assert, expect } from '@open-wc/testing';
 
 suite('ui-textbox', () => {
   test('is defined', () => {
@@ -10,22 +10,8 @@ suite('ui-textbox', () => {
     assert.instanceOf(el, Textbox);
   });
 
-  test('renders widget with correct label', async () => {
-    const label = 'Item';
-    const el = await fixture(html`<ui-textbox label="${label}"></ui-textbox>`);
-    assert.shadowDom.equal(
-      el,
-      `
-    <paper-input
-      aria-disabled="false"
-      no-float-label=""
-      label="${label}"
-      style=""
-      tabindex="0"
-      type="text"
-      value=""
-      ></paper-input>
-    `
-    );
+  test('renders widget', async () => {
+    const el = await fixture(html`<ui-textbox></ui-textbox>`);
+    expect(el.shadowRoot!.childNodes.length).to.be.greaterThan(0);
   });
 });

--- a/app-creator/src/widgets/widgets-tab/test/widget-tab_test.ts
+++ b/app-creator/src/widgets/widgets-tab/test/widget-tab_test.ts
@@ -25,4 +25,9 @@ suite('widgets-tab', () => {
     expect(widgetsTab.filterWidgets('does not exist')).to.deep.equal([]);
     expect(widgetsTab.filterWidgets('checkbox')).to.deep.equal([checkbox]);
   });
+
+  test('renders correct tag', async () => {
+    const el = await fixture(html`<widget-tab></widget-tab>`);
+    expect(el.tagName).to.equal('WIDGET-TAB');
+  });
 });

--- a/app-creator/src/widgets/widgets-tab/widgets-tab.ts
+++ b/app-creator/src/widgets/widgets-tab/widgets-tab.ts
@@ -22,6 +22,7 @@ import '../ui-checkbox/ui-checkbox';
 import '../ui-textbox/ui-textbox';
 import '../ui-slider/ui-slider';
 import '../ui-panel/ui-panel';
+import '../ui-chart/ui-chart';
 import '../search-bar/search-bar';
 import '../empty-notice/empty-notice';
 import { onSearchEvent } from '../search-bar/search-bar';
@@ -60,7 +61,7 @@ export class WidgetsTab extends LitElement {
       id: 'ui-button',
       name: 'button',
       markup: html`<h6 class="subtitle">Button</h6>
-        <draggable-widget .hasOverlay=${false}>
+        <draggable-widget>
           <ui-button id="button" label="Button"></ui-button>
         </draggable-widget>`,
     },
@@ -101,8 +102,16 @@ export class WidgetsTab extends LitElement {
       id: 'ui-checkbox',
       name: 'checkbox',
       markup: html`<h6 class="subtitle">Checkbox</h6>
-        <draggable-widget .hasOverlay=${false}>
+        <draggable-widget>
           <ui-checkbox id="checkbox" label="Item"></ui-checkbox>
+        </draggable-widget>`,
+    },
+    {
+      id: 'ui-chart',
+      name: 'chart',
+      markup: html`<h6 class="subtitle">Chart</h6>
+        <draggable-widget>
+          <ui-chart id="chart" label="Item"></ui-chart>
         </draggable-widget>`,
     },
   ];
@@ -130,7 +139,10 @@ export class WidgetsTab extends LitElement {
 
     return html`
       <tab-container title="Widgets">
-        <search-bar @onsearch=${handleSearch}></search-bar>
+        <search-bar
+          placeholder="Search for widget"
+          @onsearch=${handleSearch}
+        ></search-bar>
         ${filteredWidgets.map(({ markup }) => markup)} ${emptyNotice}
       </tab-container>
     `;

--- a/app-creator/src/widgets/widgets-tab/widgets-tab.ts
+++ b/app-creator/src/widgets/widgets-tab/widgets-tab.ts
@@ -25,6 +25,7 @@ import '../ui-panel/ui-panel';
 import '../ui-chart/ui-chart';
 import '../search-bar/search-bar';
 import '../empty-notice/empty-notice';
+import '../ui-map/ui-map';
 import { onSearchEvent } from '../search-bar/search-bar';
 
 interface WidgetItem {


### PR DESCRIPTION
## What are we adding in this PR

- [x] `ui-chart`: Widget that lets users add a chart element to their template.
- [x] `ui-map`: Allow users to edit map attributes (ie. latitude, longitude, etc..).
- [x] Export functionality which displays a serialized version of the template and allows the user to copy it. 
- [x] Added separate state variables for dragging and editing.
  
## Screenshots
**Template JSON output**
![Screenshot 2020-06-17 at 3 15 04 AM](https://user-images.githubusercontent.com/26859947/84867208-cb1c8800-b048-11ea-98ff-18cbfcfa4658.png)

**Chart widget**
![Screenshot 2020-06-17 at 3 14 13 AM](https://user-images.githubusercontent.com/26859947/84867238-d2439600-b048-11ea-8155-e50e7253b104.png)

**Map attributes**
![image](https://user-images.githubusercontent.com/26859947/84871159-2dc45280-b04e-11ea-9f0a-49a3b2cf15e8.png)
