### PR TITLE
Template duplication

### DIFF
--- a/app-creator/client/package.json
+++ b/app-creator/client/package.json
@@ -30,6 +30,7 @@
   "author": "Earth Engine Team",
   "license": "BSD-3-Clause",
   "dependencies": {
+    "@cwmr/paper-chip": "^3.0.0",
     "@polymer/iron-icons": "^3.0.1",
     "@polymer/iron-label": "^3.0.1",
     "@polymer/paper-button": "^3.0.1",

--- a/app-creator/client/src/client/fetch-templates.ts
+++ b/app-creator/client/src/client/fetch-templates.ts
@@ -27,8 +27,6 @@ export const database: TemplateItem[] = [
             "parentName": "Left Side Panel",
             "id": "left-side-panel-desktop",
             "name": "Left Side Panel Desktop",
-            "textDirection": "left",
-            "language": "en",
             "device": "desktop"
         },
         "widgets": {
@@ -65,7 +63,6 @@ export const database: TemplateItem[] = [
                     "margin": "0px",
                     "backgroundColor": "#dfd2aeFF",
                     "backgroundOpacity": "100",
-                    "borderWidth": "5px",
                     "borderColor": "#e28b59",
                     "boxSizing": "border-box"
                 }
@@ -146,8 +143,6 @@ export const database: TemplateItem[] = [
             "parentName": "Left Drawer Mobile",
             "id": "left-drawer-mobile",
             "name": "Left Side Panel Mobile",
-            "textDirection": "left",
-            "language": "en",
             "device": "mobile"
         },
         "widgets": {
@@ -188,7 +183,7 @@ export const database: TemplateItem[] = [
                     "margin": "0px",
                     "color": "black",
                     "backgroundOpacity": "100",
-                    "backgroundColor": "#FFFFFF00",
+                    "backgroundColor": "#FFFFFF",
                     "box-sizing": "border-box",
                     "position": "absolute",
                     "top":0,
@@ -270,8 +265,6 @@ export const database: TemplateItem[] = [
             "parentName": "Right Side Panel",
             "id": "right-side-panel-desktop",
             "name": "Right Side Panel Desktop",
-            "textDirection": "left",
-            "language": "en",
             "device": "desktop"
         },
         "widgets": {
@@ -387,10 +380,8 @@ export const database: TemplateItem[] = [
             "parentID": "map-with-legend",
             "parentName": "Map with legend",
             "id": "map-with-legend-desktop",
-            "name": "Map with legend Desktop",
-            "textDirection": "left",
-            "language": "en",
-            "device": "desktop"
+            "device": "desktop",
+            "name": "Map with legend Desktop"
         },
         "widgets": {
             "panel-template-0": {
@@ -426,7 +417,6 @@ export const database: TemplateItem[] = [
                     "margin": "0px",
                     "backgroundColor": "#0e1626CC",
                     "backgroundOpacity": "80",
-                    "borderWidth": "5px",
                     "borderStyle": "solid",
                     "borderColor": "#85b7b0",
                     "position": "absolute",
@@ -517,10 +507,8 @@ export const database: TemplateItem[] = [
             "parentID": "two-maps",
             "parentName": "Two Maps",
             "id": "two-maps-desktop",
-            "name": "Two Maps Desktop",
-            "textDirection": "left",
-            "language": "en",
-            "device": "desktop"
+            "device": "desktop",
+            "name": "Two Maps Desktop"
         },
         "widgets": {
             "panel-template-0": {
@@ -556,7 +544,6 @@ export const database: TemplateItem[] = [
                     "margin": "0px",
                     "backgroundColor": "#17263CF2",
                     "backgroundOpacity": "95",
-                    "borderWidth": "5px",
                     "borderStyle": "solid",
                     "borderColor": "#dfd2ae",
                     "position": "absolute",
@@ -581,7 +568,6 @@ export const database: TemplateItem[] = [
                     "margin": "0px",
                     "backgroundColor": "#DFD2AEF2",
                     "backgroundOpacity": "95",
-                    "borderWidth": "5px",
                     "borderStyle": "solid",
                     "borderColor": "#17263c",
                     "position": "absolute",
@@ -736,8 +722,6 @@ export const database: TemplateItem[] = [
             "parentName": "Four Maps",
             "id": "four-maps-desktop",
             "name": "Four Maps Desktop",
-            "textDirection": "left",
-            "language": "en",
             "device": "desktop"
         },
         "widgets": {

--- a/app-creator/client/src/client/fetch-templates.ts
+++ b/app-creator/client/src/client/fetch-templates.ts
@@ -112,7 +112,7 @@ export const database: TemplateItem[] = [
                 "id": "panel-template-0",
                 "editable": false,
                 "hasDropzone": false,
-                "children": ["map-template-0", "sidemenu-template-0"],
+                "children": ["map-template-0", "sidemenu-template-1"],
                 "uniqueAttributes": {
                     "layout": "row"
                 },
@@ -126,8 +126,8 @@ export const database: TemplateItem[] = [
                     "box-sizing": "border-box"
                 }
             },
-            "sidemenu-template-0": {
-                "id": "sidemenu-template-0",
+            "sidemenu-template-1": {
+                "id": "sidemenu-template-1",
                 "editable": true,
                 "hasDropzone": true,
                 "children": [],
@@ -482,7 +482,7 @@ export const database: TemplateItem[] = [
                 "id": "panel-template-0",
                 "editable": false,
                 "hasDropzone": false,
-                "children": ["panel-template-1", "panel-template-2"],
+                "children": ["panel-layout-1", "panel-layout-2"],
                 "uniqueAttributes": {
                     "layout": "column"
                 },
@@ -496,8 +496,8 @@ export const database: TemplateItem[] = [
                     "boxSizing": "border-box"
                 }
             },
-            "panel-template-1": {
-                "id": "panel-template-1",
+            "panel-layout-1": {
+                "id": "panel-layout-1",
                 "editable": true,
                 "hasDropzone": true,
                 "children": [],
@@ -514,11 +514,11 @@ export const database: TemplateItem[] = [
                     "boxSizing": "border-box"
                 }
             },
-            "panel-template-2": {
-                "id": "panel-template-2",
+            "panel-layout-2": {
+                "id": "panel-layout-2",
                 "editable": false,
                 "hasDropzone": false,
-                "children": ["panel-template-3", "panel-template-4"],
+                "children": ["panel-layout-3", "panel-layout-4"],
                 "uniqueAttributes": {
                     "layout": "column"
                 },
@@ -531,8 +531,8 @@ export const database: TemplateItem[] = [
                     "boxSizing": "border-box"
                 }
             },
-            "panel-template-3": {
-                "id": "panel-template-3",
+            "panel-layout-3": {
+                "id": "panel-layout-3",
                 "editable": false,
                 "hasDropzone": false,
                 "children": ["map-template-0", "map-template-1"],
@@ -550,7 +550,7 @@ export const database: TemplateItem[] = [
             },
             "map-template-0": {
                 "id": "map-template-0",
-                "children": ["panel-template-5"],
+                "children": ["panel-template-1"],
                 "uniqueAttributes": {
                     "zoom": "10",
                     "latitude": "37.419857",
@@ -573,7 +573,7 @@ export const database: TemplateItem[] = [
             },
             "map-template-1": {
                 "id": "map-template-1",
-                "children": ["panel-template-6"],
+                "children": ["panel-template-2"],
                 "uniqueAttributes": {
                     "zoom": "10",
                     "latitude": "37.419857",
@@ -594,8 +594,8 @@ export const database: TemplateItem[] = [
                     "boxSizing": "border-box"
                 }
             },
-            "panel-template-4": {
-                "id": "panel-template-4",
+            "panel-layout-4": {
+                "id": "panel-layout-4",
                 "editable": false,
                 "hasDropzone": false,
                 "children": ["map-template-2", "map-template-3"],
@@ -613,7 +613,7 @@ export const database: TemplateItem[] = [
             },
             "map-template-2": {
                 "id": "map-template-2",
-                "children": ["panel-template-7"],
+                "children": ["panel-template-3"],
                 "uniqueAttributes": {
                     "zoom": "10",
                     "latitude": "37.419857",
@@ -636,7 +636,7 @@ export const database: TemplateItem[] = [
             },
             "map-template-3": {
                 "id": "map-template-3",
-                "children": ["panel-template-8"],
+                "children": ["panel-template-4"],
                 "uniqueAttributes": {
                     "zoom": "10",
                     "latitude": "37.419857",
@@ -657,8 +657,8 @@ export const database: TemplateItem[] = [
                     "boxSizing": "border-box"
                 }
             },
-            "panel-template-5": {
-                "id": "panel-template-5",
+            "panel-template-1": {
+                "id": "panel-template-1",
                 "editable": true,
                 "hasDropzone": true,
                 "children": [],
@@ -678,8 +678,8 @@ export const database: TemplateItem[] = [
                     "zIndex": "1"
                 }
             },
-            "panel-template-6": {
-                "id": "panel-template-6",
+            "panel-template-2": {
+                "id": "panel-template-2",
                 "editable": true,
                 "hasDropzone": true,
                 "children": [],
@@ -699,8 +699,8 @@ export const database: TemplateItem[] = [
                     "zIndex": "1"
                 }
             },
-            "panel-template-7": {
-                "id": "panel-template-7",
+            "panel-template-3": {
+                "id": "panel-template-3",
                 "editable": true,
                 "hasDropzone": true,
                 "children": [],
@@ -720,8 +720,8 @@ export const database: TemplateItem[] = [
                     "zIndex": "1"
                 }
             },
-            "panel-template-8": {
-                "id": "panel-template-8",
+            "panel-template-4": {
+                "id": "panel-template-4",
                 "editable": true,
                 "hasDropzone": true,
                 "children": [],

--- a/app-creator/client/src/client/fetch-templates.ts
+++ b/app-creator/client/src/client/fetch-templates.ts
@@ -1,3 +1,5 @@
+import { DeviceType } from '../redux/types/enums';
+
 /**
  *  @fileoverview This file acts as a mock database storing our templates.
  */
@@ -5,6 +7,7 @@ export interface TemplateItem {
   id: string;
   name: string;
   imageUrl: string;
+  device: DeviceType;
   template: string;
 }
 
@@ -17,6 +20,7 @@ export const database: TemplateItem[] = [
     name: 'Left Side Panel',
     imageUrl:
       'https://storage.cloud.google.com/ee-app-creator.appspot.com/left-panel.png',
+    device: DeviceType.desktop,
     template: `{
         "config": {
             "parentID": "left-side-panel",
@@ -24,7 +28,8 @@ export const database: TemplateItem[] = [
             "id": "left-side-panel-desktop",
             "name": "Left Side Panel Desktop",
             "textDirection": "left",
-            "language": "en"
+            "language": "en",
+            "device": "desktop"
         },
         "widgets": {
             "panel-template-0": {
@@ -130,25 +135,27 @@ export const database: TemplateItem[] = [
     }`,
   },
   {
-    id: 'left-side-panel-mobile',
-    name: 'Left Side Panel Mobile',
+    id: 'left-drawer-mobile',
+    name: 'Left Drawer Mobile',
     imageUrl:
-      'https://storage.cloud.google.com/ee-app-creator.appspot.com/left-panel.png',
+      'https://storage.googleapis.com/ee-app-creator.appspot.com/left-drawer-mobile.png',
+    device: DeviceType.mobile,
     template: `{
         "config": {
-            "parentID": "left-side-panel-mobile",
-            "parentName": "Left Side Panel Mobile",
-            "id": "left-side-panel-mobile",
+            "parentID": "left-drawer-mobile",
+            "parentName": "Left Drawer Mobile",
+            "id": "left-drawer-mobile",
             "name": "Left Side Panel Mobile",
             "textDirection": "left",
-            "language": "en"
+            "language": "en",
+            "device": "mobile"
         },
         "widgets": {
             "panel-template-0": {
                 "id": "panel-template-0",
                 "editable": false,
                 "hasDropzone": false,
-                "children": ["map-template-0", "sidemenu-template-1"],
+                "children": ["map-template-0", "sidemenu-template-0"],
                 "uniqueAttributes": {
                     "layout": "row"
                 },
@@ -162,11 +169,15 @@ export const database: TemplateItem[] = [
                     "box-sizing": "border-box"
                 }
             },
-            "sidemenu-template-1": {
-                "id": "sidemenu-template-1",
+            "sidemenu-template-0": {
+                "id": "sidemenu-template-0",
                 "editable": true,
                 "hasDropzone": true,
-                "children": [],
+                "children": [
+                    "label-template-0",
+                    "label-template-1",
+                    "button-template-0"
+                ],
                 "uniqueAttributes": {
                     "layout": "column"
                 },
@@ -176,6 +187,7 @@ export const database: TemplateItem[] = [
                     "padding": "0px",
                     "margin": "0px",
                     "color": "black",
+                    "backgroundOpacity": "100",
                     "backgroundColor": "#FFFFFF00",
                     "box-sizing": "border-box",
                     "position": "absolute",
@@ -183,6 +195,41 @@ export const database: TemplateItem[] = [
                     "left":0
                 }
             },
+            "label-template-0": {
+                "id": "label-template-0",
+                "children": [],
+                "uniqueAttributes": {
+                   "value": "Earth Engine",
+                   "targetUrl": ""
+                },
+                "style": {
+                   "backgroundColor": "#FFFFFF00",
+                   "fontSize": "32px",
+                   "fontWeight": "700"
+                }
+             },
+             "label-template-1": {
+                "id": "label-template-1",
+                "children": [],
+                "uniqueAttributes": {
+                   "value": "Google Earth Engine combines a multi-petabyte catalog of satellite imagery and geospatial datasets with planetary-scale analysis capabilities and makes it available for scientists, researchers, and developers to detect changes, map trends, and quantify differences on the Earth's surface.",
+                   "targetUrl": ""
+                },
+                "style": {
+                   "backgroundColor": "#FFFFFF00"
+                }
+             },
+             "button-template-0": {
+                "id": "button-template-0",
+                "children": [],
+                "uniqueAttributes": {
+                   "label": "Button",
+                   "disabled": "false"
+                },
+                "style": {
+                   "backgroundColor": "#FFFFFF00"
+                }
+             },
             "map-template-0": {
                 "id": "map-template-0",
                 "children": [],
@@ -216,6 +263,7 @@ export const database: TemplateItem[] = [
     name: 'Right Side Panel',
     imageUrl:
       'https://storage.cloud.google.com/ee-app-creator.appspot.com/right-panel.png',
+    device: DeviceType.desktop,
     template: `{
         "config": {
             "parentID": "right-side-panel",
@@ -223,7 +271,8 @@ export const database: TemplateItem[] = [
             "id": "right-side-panel-desktop",
             "name": "Right Side Panel Desktop",
             "textDirection": "left",
-            "language": "en"
+            "language": "en",
+            "device": "desktop"
         },
         "widgets": {
             "panel-template-0": {
@@ -332,6 +381,7 @@ export const database: TemplateItem[] = [
     name: 'Map With Legend',
     imageUrl:
       'https://storage.cloud.google.com/ee-app-creator.appspot.com/legend-example.png',
+    device: DeviceType.desktop,
     template: `{
         "config": {
             "parentID": "map-with-legend",
@@ -339,7 +389,8 @@ export const database: TemplateItem[] = [
             "id": "map-with-legend-desktop",
             "name": "Map with legend Desktop",
             "textDirection": "left",
-            "language": "en"
+            "language": "en",
+            "device": "desktop"
         },
         "widgets": {
             "panel-template-0": {
@@ -460,6 +511,7 @@ export const database: TemplateItem[] = [
     name: 'Two Maps',
     imageUrl:
       'https://storage.cloud.google.com/ee-app-creator.appspot.com/two-map.png',
+    device: DeviceType.desktop,
     template: `{
         "config": {
             "parentID": "two-maps",
@@ -467,7 +519,8 @@ export const database: TemplateItem[] = [
             "id": "two-maps-desktop",
             "name": "Two Maps Desktop",
             "textDirection": "left",
-            "language": "en"
+            "language": "en",
+            "device": "desktop"
         },
         "widgets": {
             "panel-template-0": {
@@ -676,6 +729,7 @@ export const database: TemplateItem[] = [
     name: 'Four Maps',
     imageUrl:
       'https://storage.cloud.google.com/ee-app-creator.appspot.com/four-maps.png',
+    device: DeviceType.desktop,
     template: `{
         "config": {
             "parentID": "four-maps",
@@ -683,7 +737,8 @@ export const database: TemplateItem[] = [
             "id": "four-maps-desktop",
             "name": "Four Maps Desktop",
             "textDirection": "left",
-            "language": "en"
+            "language": "en",
+            "device": "desktop"
         },
         "widgets": {
             "panel-template-0": {

--- a/app-creator/client/src/client/fetch-templates.ts
+++ b/app-creator/client/src/client/fetch-templates.ts
@@ -380,8 +380,8 @@ export const database: TemplateItem[] = [
             "parentID": "map-with-legend",
             "parentName": "Map with legend",
             "id": "map-with-legend-desktop",
-            "device": "desktop",
-            "name": "Map with legend Desktop"
+            "name": "Map with legend Desktop",
+            "device": "desktop"
         },
         "widgets": {
             "panel-template-0": {
@@ -507,8 +507,8 @@ export const database: TemplateItem[] = [
             "parentID": "two-maps",
             "parentName": "Two Maps",
             "id": "two-maps-desktop",
-            "device": "desktop",
-            "name": "Two Maps Desktop"
+            "name": "Two Maps Desktop",
+            "device": "desktop"
         },
         "widgets": {
             "panel-template-0": {

--- a/app-creator/client/src/client/fetch-templates.ts
+++ b/app-creator/client/src/client/fetch-templates.ts
@@ -52,14 +52,13 @@ export const database: TemplateItem[] = [
                 "id": "panel-template-1",
                 "editable": true,
                 "hasDropzone": true,
-                "children": ["label-template-0", "label-template-1", "button-template-0"],
+                "children": [],
                 "uniqueAttributes": {
                     "layout": "column"
                 },
                 "style": {
                     "height": "100%",
                     "width": "40%",
-                    "padding": "8px",
                     "margin": "0px",
                     "backgroundColor": "#dfd2aeFF",
                     "backgroundOpacity": "100",
@@ -89,43 +88,6 @@ export const database: TemplateItem[] = [
                     "backgroundColor": "#FFFFFFFF",
                     "backgroundOpacity": "100",
                     "boxSizing": "border-box"
-                }
-            },
-            "label-template-0": {
-                "id": "label-template-0",
-                "children": [],
-                "uniqueAttributes": {
-                    "value": "Earth Engine",
-                    "targetUrl": ""
-                },
-                "style": {
-                    "backgroundColor": "#FFFFFF00",
-                    "fontSize": "32px",
-                    "fontWeight": "700"
-                }
-            },
-            "label-template-1": {
-                "id": "label-template-1",
-                "children": [],
-                "uniqueAttributes": {
-                    "value": "Google Earth Engine combines a multi-petabyte catalog of satellite imagery and geospatial datasets with planetary-scale analysis capabilities and makes it available for scientists, researchers, and developers to detect changes, map trends, and quantify differences on the Earth\'s surface.",
-                    "targetUrl": ""
-                },
-                "style": {
-                    "backgroundColor": "#FFFFFF00",
-                    "fontSize": "14px"
-                }
-            },
-            "button-template-0": {
-                "id": "button-template-0",
-                "children": [],
-                "uniqueAttributes": {
-                    "label": "Button",
-                    "disabled": "false"
-                },
-                "style": {
-                    "backgroundColor": "#FFFFFFFF",
-                    "backgroundOpacity": "100"
                 }
             }
         }
@@ -168,11 +130,7 @@ export const database: TemplateItem[] = [
                 "id": "sidemenu-template-0",
                 "editable": true,
                 "hasDropzone": true,
-                "children": [
-                    "label-template-0",
-                    "label-template-1",
-                    "button-template-0"
-                ],
+                "children": [],
                 "uniqueAttributes": {
                     "layout": "column"
                 },
@@ -190,41 +148,6 @@ export const database: TemplateItem[] = [
                     "left":0
                 }
             },
-            "label-template-0": {
-                "id": "label-template-0",
-                "children": [],
-                "uniqueAttributes": {
-                   "value": "Earth Engine",
-                   "targetUrl": ""
-                },
-                "style": {
-                   "backgroundColor": "#FFFFFF00",
-                   "fontSize": "32px",
-                   "fontWeight": "700"
-                }
-             },
-             "label-template-1": {
-                "id": "label-template-1",
-                "children": [],
-                "uniqueAttributes": {
-                   "value": "Google Earth Engine combines a multi-petabyte catalog of satellite imagery and geospatial datasets with planetary-scale analysis capabilities and makes it available for scientists, researchers, and developers to detect changes, map trends, and quantify differences on the Earth's surface.",
-                   "targetUrl": ""
-                },
-                "style": {
-                   "backgroundColor": "#FFFFFF00"
-                }
-             },
-             "button-template-0": {
-                "id": "button-template-0",
-                "children": [],
-                "uniqueAttributes": {
-                   "label": "Button",
-                   "disabled": "false"
-                },
-                "style": {
-                   "backgroundColor": "#FFFFFF00"
-                }
-             },
             "map-template-0": {
                 "id": "map-template-0",
                 "children": [],
@@ -289,7 +212,7 @@ export const database: TemplateItem[] = [
                 "id": "panel-template-1",
                 "editable": true,
                 "hasDropzone": true,
-                "children": ["label-template-0", "label-template-1", "button-template-0"],
+                "children": [],
                 "uniqueAttributes": {
                     "layout": "column"
                 },
@@ -324,46 +247,6 @@ export const database: TemplateItem[] = [
                     "backgroundColor": "#FFFFFFFF",
                     "backgroundOpacity": "100",
                     "boxSizing": "border-box"
-                }
-            },
-            "label-template-0": {
-                "id": "label-template-0",
-                "children": [],
-                "uniqueAttributes": {
-                    "value": "Earth Engine",
-                    "targetUrl": ""
-                },
-                "style": {
-                    "margin": "8px",
-                    "backgroundColor": "#FFFFFF00",
-                    "fontSize": "32px",
-                    "fontWeight": "700"
-                }
-            },
-            "label-template-1": {
-                "id": "label-template-1",
-                "children": [],
-                "uniqueAttributes": {
-                    "value": "Google Earth Engine combines a multi-petabyte catalog of satellite imagery and geospatial datasets with planetary-scale analysis capabilities and makes it available for scientists, researchers, and developers to detect changes, map trends, and quantify differences on the Earth\'s surface.",
-                    "targetUrl": ""
-                },
-                "style": {
-                    "margin": "8px",
-                    "backgroundColor": "#FFFFFF00",
-                    "fontSize": "14px"
-                }
-            },
-            "button-template-0": {
-                "id": "button-template-0",
-                "children": [],
-                "uniqueAttributes": {
-                    "label": "Button",
-                    "disabled": "false"
-                },
-                "style": {
-                    "margin": "8px",
-                    "backgroundColor": "#FFFFFFFF",
-                    "backgroundOpacity": "100"
                 }
             }
         }
@@ -406,14 +289,13 @@ export const database: TemplateItem[] = [
                 "id": "panel-template-1",
                 "editable": true,
                 "hasDropzone": true,
-                "children": ["label-template-1", "label-template-0", "button-template-0"],
+                "children": [],
                 "uniqueAttributes": {
                     "layout": "column"
                 },
                 "style": {
-                    "height": "300px",
-                    "width": "500px",
-                    "padding": "16px",
+                    "height": "200px",
+                    "width": "350px",
                     "margin": "0px",
                     "backgroundColor": "#0e1626CC",
                     "backgroundOpacity": "80",
@@ -447,50 +329,6 @@ export const database: TemplateItem[] = [
                     "backgroundColor": "#FFFFFFFF",
                     "backgroundOpacity": "100",
                     "boxSizing": "border-box"
-                }
-            },
-            "label-template-0": {
-                "id": "label-template-0",
-                "children": [],
-                "uniqueAttributes": {
-                    "value": "Google Earth Engine combines a multi-petabyte catalog of satellite imagery and geospatial datasets with planetary-scale analysis capabilities and makes it available for scientists, researchers, and developers to detect changes, map trends, and quantify differences on the surface of the earth.",
-                    "targetUrl": ""
-                },
-                "style": {
-                    "margin": "8px",
-                    "color": "#ffffff",
-                    "backgroundColor": "#FFFFFF00",
-                    "backgroundOpacity": "0px",
-                    "fontSize": "16px"
-                }
-            },
-            "button-template-0": {
-                "id": "button-template-0",
-                "children": [],
-                "uniqueAttributes": {
-                    "label": "Button",
-                    "disabled": "false"
-                },
-                "style": {
-                    "margin": "8px",
-                    "backgroundColor": "#FFFFFF",
-                    "backgroundOpacity": "0px"
-                }
-            },
-            "label-template-1": {
-                "id": "label-template-1",
-                "children": [],
-                "uniqueAttributes": {
-                    "value": "Earth Engine",
-                    "targetUrl": ""
-                },
-                "style": {
-                    "margin": "8px",
-                    "color": "#ffffff",
-                    "backgroundColor": "#FFFFFF00",
-                    "backgroundOpacity": "0px",
-                    "fontSize": "32px",
-                    "fontWeight": "700"
                 }
             }
         }
@@ -533,14 +371,13 @@ export const database: TemplateItem[] = [
                 "id": "panel-template-1",
                 "editable": true,
                 "hasDropzone": true,
-                "children": ["label-template-3", "label-template-2", "button-template-0"],
+                "children": [],
                 "uniqueAttributes": {
                     "layout": "column"
                 },
                 "style": {
-                    "height": "350px",
-                    "width": "300px",
-                    "padding": "16px",
+                    "height": "45%",
+                    "width": "250px",
                     "margin": "0px",
                     "backgroundColor": "#17263CF2",
                     "backgroundOpacity": "95",
@@ -557,14 +394,13 @@ export const database: TemplateItem[] = [
                 "id": "panel-template-2",
                 "editable": true,
                 "hasDropzone": true,
-                "children": ["label-template-4", "label-template-0", "button-template-1"],
+                "children": [],
                 "uniqueAttributes": {
                     "layout": "column"
                 },
                 "style": {
-                    "height": "350px",
-                    "width": "300px",
-                    "padding": "16px",
+                    "height": "45%",
+                    "width": "250px",
                     "margin": "0px",
                     "backgroundColor": "#DFD2AEF2",
                     "backgroundOpacity": "95",
@@ -623,91 +459,8 @@ export const database: TemplateItem[] = [
                     "backgroundOpacity": "100",
                     "boxSizing": "border-box"
                 }
-            },
-            "label-template-0": {
-                "id": "label-template-0",
-                "children": [],
-                "uniqueAttributes": {
-                    "value": "Google Earth Engine combines a multi-petabyte catalog of satellite imagery and geospatial datasets with planetary-scale analysis capabilities and makes it available for scientists, researchers, and developers to detect changes, map trends, and quantify differences on the Earth\'s surface.",
-                    "targetUrl": ""
-                },
-                "style": {
-                    "margin": "8px",
-                    "backgroundColor": "#FFFFFF00",
-                    "fontSize": "14px"
-                }
-            },
-            "label-template-2": {
-                "id": "label-template-2",
-                "children": [],
-                "uniqueAttributes": {
-                    "value": "Google Earth Engine combines a multi-petabyte catalog of satellite imagery and geospatial datasets with planetary-scale analysis capabilities and makes it available for scientists, researchers, and developers to detect changes, map trends, and quantify differences on the Earth\'s surface.",
-                    "targetUrl": ""
-                },
-                "style": {
-                    "margin": "8px",
-                    "color": "#ffffff",
-                    "backgroundColor": "#FFFFFF00",
-                    "fontSize": "14px"
-                }
-            },
-            "button-template-0": {
-                "id": "button-template-0",
-                "children": [],
-                "uniqueAttributes": {
-                    "label": "Button",
-                    "disabled": "false"
-                },
-                "style": {
-                    "margin": "8px",
-                    "backgroundColor": "#ffffffFF",
-                    "backgroundOpacity": "100"
-                }
-            },
-            "button-template-1": {
-                "id": "button-template-1",
-                "children": [],
-                "uniqueAttributes": {
-                    "label": "Button",
-                    "disabled": "false"
-                },
-                "style": {
-                    "margin": "8px",
-                    "backgroundColor": "#FFFFFFFF",
-                    "backgroundOpacity": "100"
-                }
-            },
-            "label-template-3": {
-                "id": "label-template-3",
-                "children": [],
-                "uniqueAttributes": {
-                    "value": "Earth Engine",
-                    "targetUrl": ""
-                },
-                "style": {
-                    "margin": "8px",
-                    "color": "#ffffff",
-                    "backgroundColor": "#FFFFFF00",
-                    "fontSize": "22px",
-                    "fontWeight": "700"
-                }
-            },
-            "label-template-4": {
-                "id": "label-template-4",
-                "children": [],
-                "uniqueAttributes": {
-                    "value": "Earth Engine",
-                    "targetUrl": ""
-                },
-                "style": {
-                    "margin": "8px",
-                    "backgroundColor": "#FFFFFF00",
-                    "fontSize": "22px",
-                    "fontWeight": "700"
-                }
             }
-        }
-           
+        } 
     }`,
   },
   {
@@ -747,7 +500,7 @@ export const database: TemplateItem[] = [
                 "id": "panel-template-1",
                 "editable": true,
                 "hasDropzone": true,
-                "children": ["label-template-0"],
+                "children": [],
                 "uniqueAttributes": {
                     "layout": "column"
                 },
@@ -986,29 +739,6 @@ export const database: TemplateItem[] = [
                     "right": "16px",
                     "boxSizing": "border-box",
                     "zIndex": "1"
-                }
-            },
-            "label-template-0": {
-                "id": "label-template-0",
-                "children": [],
-                "uniqueAttributes": {
-                   "value": "Earth Engine",
-                   "targetUrl": ""
-                },
-                "style": {
-                   "height": "px",
-                   "width": "98%",
-                   "margin": "8px",
-                   "backgroundColor": "#FFFFFF00",
-                   "borderWidth": "0px",
-                   "borderStyle": "solid",
-                   "borderColor": "black",
-                   "fontSize": "24px",
-                   "fontWeight": "700",
-                   "fontFamily": "Roboto",
-                   "textAlign": "center",
-                   "whiteSpace": "normal",
-                   "shown": "true"
                 }
             }
         }

--- a/app-creator/client/src/redux/actions.ts
+++ b/app-creator/client/src/redux/actions.ts
@@ -124,7 +124,9 @@ export const setPalette = (color: Palette): SetPalette => {
  */
 export const addWidgetMetaData = (
   id: string,
-  widget: Element
+  widget: Element,
+  uniqueAttributes?: UniqueAttributes,
+  style?: { [key: string]: string }
 ): AddWidgetMetaData => {
   return {
     type: ADD_WIDGET_META_DATA,
@@ -133,10 +135,10 @@ export const addWidgetMetaData = (
         id,
         widgetRef: widget as HTMLElement,
         children: [],
-        uniqueAttributes: {
+        uniqueAttributes: uniqueAttributes ?? {
           ...getUniqueAttributes(getWidgetType(id)),
         },
-        style: { ...DEFAULT_SHARED_ATTRIBUTES },
+        style: style ?? { ...DEFAULT_SHARED_ATTRIBUTES },
       },
     },
   };

--- a/app-creator/client/src/redux/actions.ts
+++ b/app-creator/client/src/redux/actions.ts
@@ -32,6 +32,8 @@ import {
   SET_PALETTE,
   SetEventType,
   SET_EVENT_TYPE,
+  UpdateWidgetIDs,
+  UPDATE_WIDGET_IDS,
 } from './types/actions';
 import {
   DEFAULT_SHARED_ATTRIBUTES,
@@ -103,6 +105,20 @@ export const removeWidgetMetaData = (
     payload: {
       id,
       reordering,
+    },
+  };
+};
+
+/**
+ * Updates widget IDs with new values. This is used after a template change to prevent id conflicts.
+ */
+export const updateWidgetIDs = (
+  updatedIDs: AppCreatorStore['widgetIDs']
+): UpdateWidgetIDs => {
+  return {
+    type: UPDATE_WIDGET_IDS,
+    payload: {
+      updatedIDs,
     },
   };
 };

--- a/app-creator/client/src/redux/actions.ts
+++ b/app-creator/client/src/redux/actions.ts
@@ -26,16 +26,24 @@ import {
   SET_SELECTED_TEMPLATE,
   UPDATE_WIDGET_CHILDREN,
   UpdateWidgetChildren,
-  SetIsImportingAction,
-  SET_IMPORTING,
   SetSelectedTemplateIDAction,
   SET_SELECTED_TEMPLATE_ID,
+  SetPalette,
+  SET_PALETTE,
+  SetEventType,
+  SET_EVENT_TYPE,
 } from './types/actions';
 import {
   DEFAULT_SHARED_ATTRIBUTES,
   UniqueAttributes,
 } from './types/attributes';
-import { WidgetType, AttributeType, Tab, EventType } from './types/enums';
+import {
+  WidgetType,
+  AttributeType,
+  Tab,
+  EventType,
+  Palette,
+} from './types/enums';
 import { getWidgetType } from '../utils/helpers';
 import { Label } from '../widgets/ui-label/ui-label';
 import { Button } from '../widgets/ui-button/ui-button';
@@ -95,6 +103,18 @@ export const removeWidgetMetaData = (
     payload: {
       id,
       reordering,
+    },
+  };
+};
+
+/**
+ * Sets the template palette.
+ */
+export const setPalette = (color: Palette): SetPalette => {
+  return {
+    type: SET_PALETTE,
+    payload: {
+      color,
     },
   };
 };
@@ -226,14 +246,16 @@ export const setReordering = (value: boolean): SetIsReorderingAction => {
 };
 
 /**
- * Sets state to true if we are importing widgets and false otherwise. Importing state is used to determine
- * if a widget should be cloned and if we should increment the widget's ID.
- * @param value true if we are importing elements and false otherwise.
+ * Sets event state to a particular value.
  */
-export const setImporting = (value: boolean): SetIsImportingAction => {
+export const setEventType = (
+  eventType: EventType,
+  value: boolean
+): SetEventType => {
   return {
-    type: SET_IMPORTING,
+    type: SET_EVENT_TYPE,
     payload: {
+      eventType,
       value,
     },
   };

--- a/app-creator/client/src/redux/actions.ts
+++ b/app-creator/client/src/redux/actions.ts
@@ -28,6 +28,8 @@ import {
   UpdateWidgetChildren,
   SetIsImportingAction,
   SET_IMPORTING,
+  SetSelectedTemplateIDAction,
+  SET_SELECTED_TEMPLATE_ID,
 } from './types/actions';
 import {
   DEFAULT_SHARED_ATTRIBUTES,
@@ -243,6 +245,20 @@ export const setImporting = (value: boolean): SetIsImportingAction => {
 export const incrementWidgetID = (id: string): IncrementWidgetAction => {
   return {
     type: INCREMENT_WIDGET_ID,
+    payload: {
+      id,
+    },
+  };
+};
+
+/**
+ * Sets selected template id.
+ */
+export const setSelectedTemplateID = (
+  id: string
+): SetSelectedTemplateIDAction => {
+  return {
+    type: SET_SELECTED_TEMPLATE_ID,
     payload: {
       id,
     },

--- a/app-creator/client/src/redux/reducer.ts
+++ b/app-creator/client/src/redux/reducer.ts
@@ -17,6 +17,7 @@ import {
   UPDATE_WIDGET_META_DATA,
   SET_SELECTED_TEMPLATE,
   UPDATE_WIDGET_CHILDREN,
+  SET_SELECTED_TEMPLATE_ID,
 } from './types/actions';
 import { Reducer, AnyAction } from 'redux';
 import { UniqueAttributes } from './types/attributes';
@@ -35,6 +36,7 @@ export interface WidgetMetaData {
 export interface AppCreatorStore {
   editingElement: Element | null;
   draggingElement: Element | null;
+  selectedTemplateID: string;
   selectedTab: Tab;
   eventType: EventType;
   widgetIDs: { [key: string]: number };
@@ -48,6 +50,7 @@ const INITIAL_STATE: AppCreatorStore = {
   editingElement: null,
   draggingElement: null,
   selectedTab: Tab.widgets,
+  selectedTemplateID: '',
   eventType: EventType.none,
   widgetIDs: {
     label: 0,
@@ -102,6 +105,11 @@ export const reducer: Reducer<AppCreatorStore, AppCreatorAction | AnyAction> = (
       return {
         ...state,
         eventType: action.payload.value ? EventType.reordering : EventType.none,
+      };
+    case SET_SELECTED_TEMPLATE_ID:
+      return {
+        ...state,
+        selectedTemplateID: action.payload.id,
       };
     case SET_IMPORTING:
       return {
@@ -197,6 +205,7 @@ export const reducer: Reducer<AppCreatorStore, AppCreatorAction | AnyAction> = (
       addDefaultStyles(action.payload.template);
       return {
         ...INITIAL_STATE,
+        selectedTemplateID: state.selectedTemplateID,
         selectedTab: state.selectedTab,
         template: action.payload.template,
       };
@@ -229,10 +238,14 @@ export const reducer: Reducer<AppCreatorStore, AppCreatorAction | AnyAction> = (
  */
 function addDefaultStyles(template: { [key: string]: any }) {
   for (const id in template.widgets) {
-    template.widgets[id].style = {
-      ...DEFAULT_STYLES,
-      ...template.widgets[id].style,
-    };
+    const styleCopy: { [key: string]: string } = Object.assign(
+      {},
+      DEFAULT_STYLES
+    );
+    for (const attribute in template.widgets[id].style) {
+      styleCopy[attribute] = template.widgets[id].style[attribute];
+    }
+    template.widgets[id].style = styleCopy;
   }
 }
 

--- a/app-creator/client/src/redux/reducer.ts
+++ b/app-creator/client/src/redux/reducer.ts
@@ -19,6 +19,7 @@ import {
   SET_SELECTED_TEMPLATE_ID,
   SET_PALETTE,
   SET_EVENT_TYPE,
+  UPDATE_WIDGET_IDS,
 } from './types/actions';
 import { Reducer, AnyAction } from 'redux';
 import { UniqueAttributes } from './types/attributes';
@@ -119,6 +120,14 @@ export const reducer: Reducer<AppCreatorStore, AppCreatorAction | AnyAction> = (
       return {
         ...state,
         selectedTemplateID: action.payload.id,
+      };
+    case UPDATE_WIDGET_IDS:
+      return {
+        ...state,
+        widgetIDs: {
+          ...state.widgetIDs,
+          ...action.payload.updatedIDs,
+        },
       };
     case SET_EVENT_TYPE:
       return {

--- a/app-creator/client/src/redux/types/actions.ts
+++ b/app-creator/client/src/redux/types/actions.ts
@@ -17,6 +17,7 @@ export const REMOVE_WIDGET = 'REMOVE_WIDGET';
 export const UPDATE_WIDGET_META_DATA = 'UPDATE_WIDGET_META_DATA';
 export const SET_SELECTED_TEMPLATE = 'SET_SELECTED_TEMPLATE';
 export const UPDATE_WIDGET_CHILDREN = 'UPDATE_WIDGET_CHILDREN';
+export const SET_SELECTED_TEMPLATE_ID = 'SET_SELECTED_TEMPLATE_ID';
 
 export interface UpdateWidgetChildren {
   type: typeof UPDATE_WIDGET_CHILDREN;
@@ -31,6 +32,13 @@ export interface RemoveWidget {
   payload: {
     id: string;
     reordering: boolean;
+  };
+}
+
+export interface SetSelectedTemplateIDAction {
+  type: typeof SET_SELECTED_TEMPLATE_ID;
+  payload: {
+    id: string;
   };
 }
 

--- a/app-creator/client/src/redux/types/actions.ts
+++ b/app-creator/client/src/redux/types/actions.ts
@@ -19,6 +19,7 @@ export const UPDATE_WIDGET_CHILDREN = 'UPDATE_WIDGET_CHILDREN';
 export const SET_SELECTED_TEMPLATE_ID = 'SET_SELECTED_TEMPLATE_ID';
 export const SET_PALETTE = 'SET_PALETTE';
 export const SET_EVENT_TYPE = 'SET_EVENT_TYPE';
+export const UPDATE_WIDGET_IDS = 'UPDATE_WIDGET_IDS';
 
 export interface UpdateWidgetChildren {
   type: typeof UPDATE_WIDGET_CHILDREN;
@@ -33,6 +34,13 @@ export interface RemoveWidget {
   payload: {
     id: string;
     reordering: boolean;
+  };
+}
+
+export interface UpdateWidgetIDs {
+  type: typeof UPDATE_WIDGET_IDS;
+  payload: {
+    updatedIDs: AppCreatorStore['widgetIDs'];
   };
 }
 

--- a/app-creator/client/src/redux/types/actions.ts
+++ b/app-creator/client/src/redux/types/actions.ts
@@ -1,7 +1,7 @@
 /**
  *  @fileoverview This file contains the type interfaces for each action in our store.
  */
-import { EventType, AttributeType, Tab } from './enums';
+import { EventType, AttributeType, Tab, Palette } from './enums';
 import { AppCreatorStore } from '../reducer';
 
 export const SET_DRAGGING_WIDGET = 'SET_DRAGGING_WIDGET';
@@ -9,7 +9,6 @@ export const SET_EDITING_WIDGET = 'SET_EDITING_WIDGET';
 export const SET_ELEMENT_ADDED = 'SET_ELEMENT_ADDED';
 export const SET_SELECTED_TAB = 'SET_SELECTED_TAB';
 export const SET_REORDERING = 'SET_REORDERING';
-export const SET_IMPORTING = 'SET_IMPORTING';
 export const INCREMENT_WIDGET_ID = 'INCREMENT_WIDGET_ID';
 export const RESET_DRAGGING_VALUES = 'RESET_DRAGGING_VALUES';
 export const ADD_WIDGET_META_DATA = 'ADD_WIDGET_META_DATA';
@@ -18,6 +17,8 @@ export const UPDATE_WIDGET_META_DATA = 'UPDATE_WIDGET_META_DATA';
 export const SET_SELECTED_TEMPLATE = 'SET_SELECTED_TEMPLATE';
 export const UPDATE_WIDGET_CHILDREN = 'UPDATE_WIDGET_CHILDREN';
 export const SET_SELECTED_TEMPLATE_ID = 'SET_SELECTED_TEMPLATE_ID';
+export const SET_PALETTE = 'SET_PALETTE';
+export const SET_EVENT_TYPE = 'SET_EVENT_TYPE';
 
 export interface UpdateWidgetChildren {
   type: typeof UPDATE_WIDGET_CHILDREN;
@@ -39,6 +40,21 @@ export interface SetSelectedTemplateIDAction {
   type: typeof SET_SELECTED_TEMPLATE_ID;
   payload: {
     id: string;
+  };
+}
+
+export interface SetEventType {
+  type: typeof SET_EVENT_TYPE;
+  payload: {
+    eventType: EventType;
+    value: boolean;
+  };
+}
+
+export interface SetPalette {
+  type: typeof SET_PALETTE;
+  payload: {
+    color: Palette;
   };
 }
 
@@ -124,13 +140,6 @@ export interface SetIsReorderingAction {
   };
 }
 
-export interface SetIsImportingAction {
-  type: typeof SET_IMPORTING;
-  payload: {
-    value: boolean;
-  };
-}
-
 export type AppCreatorAction =
   | SetDraggingWidgetAction
   | SetEditingWidgetAction
@@ -143,5 +152,4 @@ export type AppCreatorAction =
   | AddWidgetMetaData
   | RemoveWidget
   | UpdateWidgetMetaData
-  | UpdateWidgetChildren
-  | SetIsImportingAction;
+  | UpdateWidgetChildren;

--- a/app-creator/client/src/redux/types/enums.ts
+++ b/app-creator/client/src/redux/types/enums.ts
@@ -34,8 +34,8 @@ export enum AttributeType {
 export enum EventType {
   editing = 'editing',
   reordering = 'reordering',
-  importing = 'importing',
   adding = 'adding',
+  changingPalette = 'changingPalette',
   none = 'none',
 }
 
@@ -48,4 +48,13 @@ export enum DeviceType {
 export enum Layout {
   COLUMN = 'COLUMN',
   ROW = 'ROW',
+}
+
+export enum Palette {
+  light = 'light',
+  dark = 'dark',
+  night = 'night',
+  retro = 'retro',
+  silver = 'silver',
+  aubergine = 'aubergine',
 }

--- a/app-creator/client/src/redux/types/enums.ts
+++ b/app-creator/client/src/redux/types/enums.ts
@@ -36,6 +36,7 @@ export enum EventType {
   reordering = 'reordering',
   adding = 'adding',
   changingPalette = 'changingPalette',
+  changingTemplate = 'changingTemplate',
   none = 'none',
 }
 

--- a/app-creator/client/src/redux/types/enums.ts
+++ b/app-creator/client/src/redux/types/enums.ts
@@ -1,3 +1,4 @@
+// TODO: Convert all enum properties to uppercase.
 export enum InputType {
   text = 'text',
   textarea = 'textarea',
@@ -41,4 +42,10 @@ export enum EventType {
 export enum DeviceType {
   desktop = 'desktop',
   mobile = 'mobile',
+  all = 'all',
+}
+
+export enum Layout {
+  COLUMN = 'COLUMN',
+  ROW = 'ROW',
 }

--- a/app-creator/client/src/utils/helpers.ts
+++ b/app-creator/client/src/utils/helpers.ts
@@ -46,3 +46,12 @@ export const chips = [
     device: DeviceType.mobile,
   },
 ];
+
+/*
+ * Generates random ids with length 32.
+ */
+export function generateRandomId() {
+  return [...Array(32)]
+    .map((_) => (~~(Math.random() * 36)).toString(36))
+    .join('');
+}

--- a/app-creator/client/src/utils/helpers.ts
+++ b/app-creator/client/src/utils/helpers.ts
@@ -47,7 +47,7 @@ export const chips = [
   },
 ];
 
-/*
+/**
  * Generates random ids with length 32.
  */
 export function generateRandomId() {

--- a/app-creator/client/src/utils/helpers.ts
+++ b/app-creator/client/src/utils/helpers.ts
@@ -1,6 +1,7 @@
 import { DeviceType } from '../redux/types/enums';
 import { AppCreatorStore } from '../redux/reducer';
 import { WIDGET_REF } from './constants';
+import { store } from '../redux/store';
 
 /**
  * Converts camel case to title case.
@@ -84,4 +85,22 @@ export function deepCloneTemplate(
   }
 
   return clone;
+}
+
+/**
+ * Takes a snapshot of the current template and stores it in localStorage.
+ */
+export function storeTemplateInLocalStorage() {
+  try {
+    /**
+     * Saving current template string in localStorage so we can transfer data across.
+     * */
+    const currentTemplate = JSON.stringify(
+      deepCloneTemplate(store.getState().template)
+    );
+
+    localStorage.setItem('previousTemplate', currentTemplate);
+  } catch (e) {
+    throw e;
+  }
 }

--- a/app-creator/client/src/utils/helpers.ts
+++ b/app-creator/client/src/utils/helpers.ts
@@ -1,3 +1,5 @@
+import { DeviceType } from '../redux/types/enums';
+
 /**
  * Converts camel case to title case.
  * ie. helloWorld => Hello World
@@ -26,3 +28,21 @@ export function getIdPrefixLastIndex(id: string) {
  * Empty function. Used as a placeholder.
  */
 export const noop: VoidFunction = () => {};
+
+/**
+ * List of chip data used for sorting templates by device type.
+ */
+export const chips = [
+  {
+    label: 'All',
+    device: DeviceType.all,
+  },
+  {
+    label: 'Web',
+    device: DeviceType.desktop,
+  },
+  {
+    label: 'Mobile',
+    device: DeviceType.mobile,
+  },
+];

--- a/app-creator/client/src/utils/helpers.ts
+++ b/app-creator/client/src/utils/helpers.ts
@@ -1,4 +1,6 @@
 import { DeviceType } from '../redux/types/enums';
+import { AppCreatorStore } from '../redux/reducer';
+import { WIDGET_REF } from './constants';
 
 /**
  * Converts camel case to title case.
@@ -54,4 +56,32 @@ export function generateRandomId() {
   return [...Array(32)]
     .map((_) => (~~(Math.random() * 36)).toString(36))
     .join('');
+}
+
+/**
+ * Returns a deep clone of template without widgetRefs.
+ */
+export function deepCloneTemplate(
+  template: AppCreatorStore['template']
+): AppCreatorStore['template'] {
+  const clone: AppCreatorStore['template'] = {};
+  for (const key in template) {
+    /**
+     * Widget refs are only needed in the context of the app creator. Once we serialize the data,
+     * we no longer need to keep the refs. As a result, we skip over them when we are producing the
+     * output string.
+     */
+    if (key === WIDGET_REF) {
+      continue;
+    }
+    if (typeof template[key] === 'object' && !Array.isArray(template[key])) {
+      clone[key] = deepCloneTemplate(template[key]);
+    } else if (Array.isArray(template[key])) {
+      clone[key] = template[key].slice();
+    } else {
+      clone[key] = template[key];
+    }
+  }
+
+  return clone;
 }

--- a/app-creator/client/src/utils/palettes.ts
+++ b/app-creator/client/src/utils/palettes.ts
@@ -1,0 +1,42 @@
+import { Palette } from '../redux/types/enums';
+
+type PaletteMap = {
+  [key in Palette]: {
+    backgroundColor: string;
+    color: string;
+    map: string;
+  };
+};
+
+export const palette: PaletteMap = {
+  light: {
+    backgroundColor: 'white',
+    color: 'black',
+    map: 'standard',
+  },
+  silver: {
+    backgroundColor: 'white',
+    color: 'black',
+    map: 'silver',
+  },
+  dark: {
+    backgroundColor: 'black',
+    color: 'white',
+    map: 'dark',
+  },
+  night: {
+    backgroundColor: '#17263C',
+    color: 'white',
+    map: 'night',
+  },
+  retro: {
+    backgroundColor: '#DFD2AE',
+    color: 'black',
+    map: 'retro',
+  },
+  aubergine: {
+    backgroundColor: '#0E1626',
+    color: 'white',
+    map: 'aubergine',
+  },
+};

--- a/app-creator/client/src/utils/template-generation.ts
+++ b/app-creator/client/src/utils/template-generation.ts
@@ -5,12 +5,18 @@
 import { AppCreatorStore, WidgetMetaData } from '../redux/reducer';
 import { ROOT_ID } from './constants';
 import { store } from '../redux/store';
-import { setSelectedTemplate } from '../redux/actions';
+import {
+  setSelectedTemplate,
+  addWidgetMetaData,
+  updateWidgetChildren,
+  setEventType,
+  updateWidgetIDs,
+} from '../redux/actions';
 import { Dropzone } from '../widgets/dropzone-widget/dropzone-widget';
 import { DraggableWidget } from '../widgets/draggable-widget/draggable-widget';
 import { getWidgetType } from './helpers';
 import { EEWidget } from '../redux/types/types';
-import { WidgetType } from '../redux/types/enums';
+import { WidgetType, EventType } from '../redux/types/enums';
 import { Panel } from '../widgets/ui-panel/ui-panel';
 import { Map } from '../widgets/ui-map/ui-map';
 import { SideMenu } from '../widgets/ui-sidemenu/ui-sidemenu';
@@ -24,7 +30,6 @@ export function generateUI(
   node: HTMLElement
 ) {
   const templateCopy = Object.assign({}, template);
-
   // Recursively creates ui widgets and returns the root of the tree.
   function getWidgetTree(widgetData: WidgetMetaData): HTMLElement {
     const { id, children } = widgetData;
@@ -134,4 +139,95 @@ export function getWidgetElement({
   }
 
   return { element, dropzone, map, draggable };
+}
+
+/**
+ * Retrieves previous template from store and populates user added widgets.
+ */
+export function transferData() {
+  try {
+    const template = localStorage.getItem('previousTemplate');
+
+    if (template) {
+      const templateJSON = JSON.parse(template);
+      const widgets = templateJSON.widgets;
+      const panelIDs = [];
+
+      // Get all panels that are not the root and that exist in the new and old template.
+      for (const widgetID in widgets) {
+        if (
+          widgetID !== ROOT_ID &&
+          (widgetID.startsWith('panel') || widgetID.startsWith('sidemenu')) &&
+          store.getState().template.widgets.hasOwnProperty(widgetID)
+        ) {
+          panelIDs.push(widgetID);
+        }
+      }
+
+      /**
+       * Populating store with widgets that share the same IDs.
+       */
+      for (const panelID of panelIDs) {
+        for (const child of widgets[panelID].children) {
+          const childMetaData: WidgetMetaData = widgets[child];
+          const { id, uniqueAttributes, style } = childMetaData;
+
+          const { element } = getWidgetElement(childMetaData);
+          store.dispatch(
+            addWidgetMetaData(id, element, uniqueAttributes, style)
+          );
+
+          store.dispatch(
+            updateWidgetChildren(panelID, [
+              ...store.getState().template.widgets[panelID].children,
+              id,
+            ])
+          );
+        }
+      }
+
+      /**
+       * Getting remainding widgets that have not been added.
+       */
+      const remainingWidgetIDs: string[] = [];
+      for (const id in widgets) {
+        if (
+          !id.startsWith('panel') &&
+          !id.startsWith('sidemenu') &&
+          !(id in store.getState().template.widgets)
+        ) {
+          remainingWidgetIDs.push(id);
+        }
+      }
+
+      store.dispatch(setEventType(EventType.changingTemplate, true));
+    }
+  } catch (e) {
+    throw e;
+  }
+}
+
+/**
+ * Updates widget IDs. Since we pre-populate the template by widgets from the previous template,
+ * we need to increment the widget IDs in our store to match the new widgets.
+ */
+export function incrementWidgetIDs(widgets: { [key: string]: WidgetMetaData }) {
+  const updatedIDs: AppCreatorStore['widgetIDs'] = {};
+  for (const key in store.getState().widgetIDs) {
+    let largest = -Infinity;
+    for (const widgetID in widgets) {
+      const type = getWidgetType(widgetID);
+      if (type === key) {
+        const idCount = parseInt(widgetID.slice(widgetID.lastIndexOf('-') + 1));
+        largest = Math.max(largest, idCount);
+      }
+    }
+    if (largest !== -Infinity) {
+      updatedIDs[key] = largest + 1;
+    }
+  }
+
+  store.dispatch(updateWidgetIDs(updatedIDs));
+
+  localStorage.removeItem('previousTemplate');
 }

--- a/app-creator/client/src/utils/template-generation.ts
+++ b/app-creator/client/src/utils/template-generation.ts
@@ -110,11 +110,11 @@ export function getWidgetElement({
     case WidgetType.panel:
     case WidgetType.sidemenu:
       if ((element as Panel).editable) {
-        (element as Panel).editable = editable ?? false;
+        (element as Panel).editable = !!editable;
       }
 
       if ((element as SideMenu).editable) {
-        (element as SideMenu).editable = editable ?? false;
+        (element as SideMenu).editable = !!editable;
       }
 
       if (editable) {

--- a/app-creator/client/src/widgets/app-root.ts
+++ b/app-creator/client/src/widgets/app-root.ts
@@ -192,6 +192,10 @@ export class AppRoot extends LitElement {
     };
   }
 
+  handleDeviceFilters(device: DeviceType) {
+    this.deviceFilter = device;
+  }
+
   getTemplateCards(showTitle = false): Array<TemplatesTabItem> {
     return this.templates.map(({ id, name, imageUrl, device, template }) => {
       return {

--- a/app-creator/client/src/widgets/app-root.ts
+++ b/app-creator/client/src/widgets/app-root.ts
@@ -1,27 +1,8 @@
 /**
  *  @fileoverview The app-root widget is the starting point of our application
- *  in which all other widgets are rendered
+ *  in which all other widgets are rendered.
  */
-import {
-  LitElement,
-  html,
-  customElement,
-  css,
-  property,
-  query,
-} from 'lit-element';
-import { classMap } from 'lit-html/directives/class-map';
-import { nothing } from 'lit-html';
-import { PaperToastElement } from '@polymer/paper-toast/paper-toast.js';
-import { PaperDialogElement } from '@polymer/paper-dialog/paper-dialog.js';
-import { onSearchEvent } from './search-bar/search-bar';
-import { TemplatesTab, TemplatesTabItem } from './templates-tab/templates-tab';
-import { store } from '../redux/store';
-import { setSelectedTemplate } from '../redux/actions';
-import { TemplateItem } from '../client/fetch-templates';
-import { templatesManager } from '../data/templates';
-import { DeviceType } from '../redux/types/enums';
-import { chips } from '../utils/helpers';
+import { LitElement, html, customElement, css } from 'lit-element';
 import './tool-bar/tool-bar';
 import './actions-panel/actions-panel';
 import './tab-container/tab-container';
@@ -30,6 +11,7 @@ import './search-bar/search-bar';
 import '@polymer/paper-progress/paper-progress.js';
 import '@polymer/paper-toast/paper-toast.js';
 import '@cwmr/paper-chip/paper-chip.js';
+import './template-wizard/template-wizard';
 
 @customElement('app-root')
 export class AppRoot extends LitElement {
@@ -48,6 +30,8 @@ export class AppRoot extends LitElement {
     #storyboard {
       height: 90%;
       width: 90%;
+      display: flex;
+      align-items: center;
     }
 
     #storyboard-container {
@@ -58,230 +42,9 @@ export class AppRoot extends LitElement {
       height: 100%;
       width: 100%;
     }
-
-    #cards-container {
-      display: flex;
-      flex-wrap: wrap;
-      justify-content: center;
-      width: 100%;
-      margin-top: var(--regular);
-    }
-
-    template-card {
-      width: 200px;
-      margin: var(--regular);
-    }
-
-    paper-dialog {
-      width: 800px;
-      height: 500px;
-      padding: var(--regular);
-      border-radius: var(--tight);
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      overflow-y: scroll;
-    }
-
-    #header-content {
-      width: 400px;
-    }
-
-    .subtitle {
-      margin: 0;
-      font-size: 1rem;
-      color: var(--accent-color);
-      font-weight: 500;
-    }
-
-    #modal-title {
-      text-align: center;
-      font-weight: 500;
-      color: var(--accent-color);
-    }
-
-    paper-progress {
-      width: 100%;
-      height: 20px;
-      z-index: 10;
-      position: absolute;
-      top: 0;
-      left: 0;
-      margin: 0px;
-    }
-
-    #chips-container {
-      display: flex;
-      flex-wrap: wrap;
-      align-items: center;
-      justify-content: center;
-      margin-top: var(--tight);
-    }
-
-    paper-chip {
-      margin: 0px var(--extra-tight);
-      background-color: var(--primary-color);
-      color: var(--accent-color);
-    }
-
-    .selected-paper-chip {
-      background-color: var(--accent-color);
-      color: var(--primary-color);
-    }
   `;
 
-  /**
-   * Sets template dialog search query.
-   */
-  @property({ type: String }) query = '';
-
-  /**
-   * Sets device filter.
-   */
-  @property({ type: String }) deviceFilter: DeviceType = DeviceType.all;
-
-  /**
-   * Array of templates.
-   */
-  @property({ type: Array }) templates: TemplateItem[] = [];
-
-  /**
-   * Loading state.
-   */
-  @property({ type: Boolean }) loading = false;
-
-  /**
-   * Reference to dialog element.
-   */
-  @query('paper-dialog') dialog!: PaperDialogElement;
-
-  async firstUpdated() {
-    try {
-      this.loading = true;
-
-      const templates = await templatesManager.fetchTemplates(false);
-      if (templates != null) {
-        this.templates = templates;
-      }
-    } catch (e) {
-      const fetchErrorToast = this.shadowRoot?.getElementById(
-        'fetch-error-toast'
-      ) as PaperToastElement;
-
-      if (fetchErrorToast != null) {
-        fetchErrorToast.open();
-      }
-      this.templates = templatesManager.getTemplates();
-    } finally {
-      this.loading = false;
-    }
-    this.showTemplateSelectionModal();
-  }
-
-  showTemplateSelectionModal() {
-    this.dialog.open();
-  }
-
-  createSelectionCallback(template: string): VoidFunction {
-    return () => {
-      const { dialog } = this;
-      if (dialog != null) {
-        dialog.close();
-        store.dispatch(setSelectedTemplate(JSON.parse(template)));
-      }
-    };
-  }
-
-  handleDeviceFilters(device: DeviceType) {
-    this.deviceFilter = device;
-  }
-
-  getTemplateCards(showTitle = false): Array<TemplatesTabItem> {
-    return this.templates.map(({ id, name, imageUrl, device, template }) => {
-      return {
-        id,
-        name,
-        device,
-        markup: html`
-          ${showTitle ? nothing : html`<h6 class="subtitle">${name}</h6>`}
-          <template-card
-            id="${id}"
-            title="${name}"
-            imageUrl="${imageUrl}"
-            ?showTitle=${showTitle}
-            .onSelection=${this.createSelectionCallback(template)}
-          ></template-card>
-        `,
-      };
-    });
-  }
-
-  /**
-   * Sets the query property when an onsearch event is dispatched from the
-   * searchbar widget.
-   */
-  handleSearch({ detail: { query } }: onSearchEvent) {
-    this.query = query.trim();
-  }
-
   render() {
-    const {
-      handleSearch,
-      getTemplateCards,
-      deviceFilter,
-      query,
-      loading,
-    } = this;
-
-    const templateCards = getTemplateCards.call(this, true);
-    const filteredTemplates = TemplatesTab.filterTemplates(
-      templateCards,
-      query,
-      deviceFilter
-    );
-
-    const emptyNotice = html`
-      <empty-notice
-        id="empty-notice"
-        icon="search"
-        message='No templates match "${query}". Please search again.'
-        size="large"
-        bold
-      ></empty-notice>
-    `;
-
-    const contentMarkup = loading
-      ? nothing
-      : html`
-          <div id="cards-container">
-            ${filteredTemplates.map(({ markup }) => markup)}
-            ${filteredTemplates.length === 0 ? emptyNotice : nothing}
-          </div>
-        `;
-
-    const loadingBar = loading
-      ? html`<paper-progress indeterminate></paper-progress>`
-      : nothing;
-
-    const sortingChips = html`
-      <div id="chips-container">
-        ${chips.map(({ label, device }) => {
-          return html`
-            <paper-chip
-              selectable
-              class=${classMap({
-                'selected-paper-chip': this.deviceFilter === device,
-              })}
-              @click=${() => {
-                this.deviceFilter = device;
-              }}
-              >${label}</paper-chip
-            >
-          `;
-        })}
-      </div>
-    `;
-
     return html`
       <div id="app">
         <tool-bar></tool-bar>
@@ -290,24 +53,7 @@ export class AppRoot extends LitElement {
           <div id="storyboard-container">
             <story-board id="storyboard"></story-board>
           </div>
-
-          <paper-dialog with-backdrop no-cancel-on-outside-click>
-            ${loadingBar}
-            <div id="header-content">
-              <h2 id="modal-title">Select Template</h2>
-              <search-bar
-                placeholder="Search for template (i.e. side panel)"
-                @onsearch=${handleSearch}
-              ></search-bar>
-              ${sortingChips}
-            </div>
-            ${contentMarkup}
-          </paper-dialog>
-
-          <paper-toast
-            id="fetch-error-toast"
-            text="Unable to fetch the latest templates from the server."
-          ></paper-toast>
+          <template-wizard></template-wizard>
         </div>
       </div>
     `;

--- a/app-creator/client/src/widgets/app-root.ts
+++ b/app-creator/client/src/widgets/app-root.ts
@@ -54,7 +54,7 @@ export class AppRoot extends LitElement {
           <div id="storyboard-container">
             <story-board id="storyboard"></story-board>
           </div>
-          <scratch-panel></scratch-panel>
+          <!-- <scratch-panel></scratch-panel> -->
           <template-wizard></template-wizard>
         </div>
       </div>

--- a/app-creator/client/src/widgets/app-root.ts
+++ b/app-creator/client/src/widgets/app-root.ts
@@ -3,14 +3,14 @@
  *  in which all other widgets are rendered.
  */
 import { LitElement, html, customElement, css } from 'lit-element';
+import '@polymer/paper-progress/paper-progress.js';
+import '@polymer/paper-toast/paper-toast.js';
+import '@cwmr/paper-chip/paper-chip.js';
 import './tool-bar/tool-bar';
 import './actions-panel/actions-panel';
 import './tab-container/tab-container';
 import './story-board/story-board';
 import './search-bar/search-bar';
-import '@polymer/paper-progress/paper-progress.js';
-import '@polymer/paper-toast/paper-toast.js';
-import '@cwmr/paper-chip/paper-chip.js';
 import './template-wizard/template-wizard';
 import './scratch-panel/scratch-panel';
 
@@ -54,7 +54,6 @@ export class AppRoot extends LitElement {
           <div id="storyboard-container">
             <story-board id="storyboard"></story-board>
           </div>
-          <!-- <scratch-panel></scratch-panel> -->
           <template-wizard></template-wizard>
         </div>
       </div>

--- a/app-creator/client/src/widgets/app-root.ts
+++ b/app-creator/client/src/widgets/app-root.ts
@@ -12,6 +12,7 @@ import '@polymer/paper-progress/paper-progress.js';
 import '@polymer/paper-toast/paper-toast.js';
 import '@cwmr/paper-chip/paper-chip.js';
 import './template-wizard/template-wizard';
+import './scratch-panel/scratch-panel';
 
 @customElement('app-root')
 export class AppRoot extends LitElement {
@@ -53,6 +54,7 @@ export class AppRoot extends LitElement {
           <div id="storyboard-container">
             <story-board id="storyboard"></story-board>
           </div>
+          <scratch-panel></scratch-panel>
           <template-wizard></template-wizard>
         </div>
       </div>

--- a/app-creator/client/src/widgets/draggable-widget/draggable-widget.ts
+++ b/app-creator/client/src/widgets/draggable-widget/draggable-widget.ts
@@ -50,6 +50,7 @@ export class DraggableWidget extends LitElement {
 
     .edit-buttons {
       background-color: white;
+      color: black;
       border: var(--light-border);
       border-radius: var(--extra-tight);
       margin-left: var(--extra-tight);

--- a/app-creator/client/src/widgets/draggable-widget/draggable-widget.ts
+++ b/app-creator/client/src/widgets/draggable-widget/draggable-widget.ts
@@ -91,8 +91,15 @@ export class DraggableWidget extends LitElement {
 
     const type = getWidgetType(editingWidget.id) as WidgetType;
 
-    if (type === WidgetType.panel) {
-      const dropzone = editingWidget.querySelector('dropzone-widget');
+    if (type === WidgetType.panel || type === WidgetType.sidemenu) {
+      let dropzone = editingWidget.querySelector('dropzone-widget');
+
+      if (dropzone == null) {
+        dropzone = editingWidget
+          .querySelector('slot')
+          ?.assignedNodes()
+          .find((node) => node.nodeName === 'DROPZONE-WIDGET') as Dropzone;
+      }
 
       if (dropzone != null) {
         (dropzone as Dropzone).setStyleProperty(

--- a/app-creator/client/src/widgets/dropzone-widget/dropzone-widget.ts
+++ b/app-creator/client/src/widgets/dropzone-widget/dropzone-widget.ts
@@ -3,9 +3,7 @@
  */
 import { css, customElement, html, LitElement, property } from 'lit-element';
 import { styleMap } from 'lit-html/directives/style-map';
-import '@polymer/iron-icon/iron-icon.js';
 import { DraggableWidget } from '../draggable-widget/draggable-widget';
-import '../empty-notice/empty-notice';
 import { EMPTY_NOTICE_ID } from '../empty-notice/empty-notice';
 import { store } from '../../redux/store';
 import {
@@ -16,6 +14,8 @@ import {
   updateWidgetChildren,
 } from '../../redux/actions';
 import { EventType } from '../../redux/types/enums';
+import '@polymer/iron-icon/iron-icon.js';
+import '../empty-notice/empty-notice';
 
 export const CONTAINER_ID = 'container';
 

--- a/app-creator/client/src/widgets/dropzone-widget/dropzone-widget.ts
+++ b/app-creator/client/src/widgets/dropzone-widget/dropzone-widget.ts
@@ -83,10 +83,9 @@ export class Dropzone extends LitElement {
   }
 
   /**
-   * Takes in an html element (usually a dropzone) and returns the children ids without the empty-notice.
+   * Return children IDs for a given dropzone.
    */
   getChildrenIds(): string[] {
-    // We slice the first child because it is always the empty notice.
     return Array.from(this.children).map((el) => {
       return el.firstElementChild!.id;
     });
@@ -132,15 +131,20 @@ export class Dropzone extends LitElement {
     clone.id += `-${store.getState().widgetIDs[widget.id]}`;
 
     // Return early if the widget has been added to another panel earlier.
-    const template = store.getState().template.widgets;
-    for (const id in template) {
+    const widgets = store.getState().template.widgets;
+    for (const id in widgets) {
       if (
-        typeof template[id] === 'object' &&
-        !Array.isArray(template[id]) &&
+        typeof widgets[id] === 'object' &&
+        !Array.isArray(widgets[id]) &&
         id !== parent!.id &&
-        template[id].children.includes(clone.id)
+        widgets[id].children.includes(clone.id)
       ) {
-        return;
+        const widget = widgets[clone.id].widgetRef;
+        const draggable = widget.parentElement as DraggableWidget;
+        const dropzone = draggable.parentElement as Dropzone;
+        dropzone.removeChild(draggable);
+        const childrenIDs = dropzone.getChildrenIds();
+        store.dispatch(updateWidgetChildren(id, childrenIDs));
       }
     }
 

--- a/app-creator/client/src/widgets/scratch-panel/scratch-panel.ts
+++ b/app-creator/client/src/widgets/scratch-panel/scratch-panel.ts
@@ -42,9 +42,9 @@ export class ScratchPanel extends LitElement {
 
     paper-tabs {
       border-bottom: var(--light-border);
+      height: 40px;
       --iron-icon-height: 18px;
       --iron-icon-width: 18px;
-      height: 40px;
     }
   `;
 
@@ -71,8 +71,8 @@ export class ScratchPanel extends LitElement {
     return html`
       <div id="container">
         <div id="panel">
-          <paper-tabs noink>
-            <paper-tab>
+          <paper-tabs disabled noink>
+            <paper-tab disabled>
               <iron-icon icon="icons:select-all"></iron-icon>
             </paper-tab>
           </paper-tabs>
@@ -81,7 +81,6 @@ export class ScratchPanel extends LitElement {
             id="toggle-side-panel"
             icon="icons:chevron-right"
           ></iron-icon>
-
           <tab-container title="Shared Widgets">
             <dropzone-widget></dropzone-widget>
           </tab-container>

--- a/app-creator/client/src/widgets/scratch-panel/scratch-panel.ts
+++ b/app-creator/client/src/widgets/scratch-panel/scratch-panel.ts
@@ -1,0 +1,98 @@
+/**
+ *  @fileoverview The scratch-panel widget is the right side panel in that stores intermediary
+ */
+import { LitElement, html, customElement, css } from 'lit-element';
+import { IronIconElement } from '@polymer/iron-icon';
+import '@polymer/iron-icon/iron-icon.js';
+import '@polymer/iron-icons/iron-icons.js';
+import '@polymer/paper-tabs/paper-tabs';
+import '@polymer/paper-tabs/paper-tab';
+import '../tab-container/tab-container';
+import '../dropzone-widget/dropzone-widget';
+
+@customElement('scratch-panel')
+export class ScratchPanel extends LitElement {
+  static styles = css`
+    #container {
+      width: var(--actions-panel-width);
+      height: 100%;
+      border-left: var(--light-border);
+      display: flex;
+      position: relative;
+      background-color: var(--primary-color);
+    }
+
+    #toggle-side-panel {
+      position: absolute;
+      cursor: pointer;
+      top: 16px;
+      left: -20px;
+      background-color: white;
+      border: var(--light-border);
+      border-right: none;
+      z-index: 10;
+      --iron-icon-height: 18px;
+      --iron-icon-width: 18px;
+    }
+
+    #panel {
+      width: 100%;
+      overflow-x: hidden;
+    }
+
+    paper-tabs {
+      border-bottom: var(--light-border);
+      --iron-icon-height: 18px;
+      --iron-icon-width: 18px;
+      height: 40px;
+    }
+  `;
+
+  /**
+   * Collapses/Expands the actions panel.
+   */
+  togglePanel({ target }: { target: EventTarget }) {
+    const panel = this.shadowRoot?.getElementById('container');
+
+    if (panel == null) {
+      return;
+    }
+
+    if (panel.style.width === '0px') {
+      panel.style.width = 'var(--actions-panel-width)';
+      (target as IronIconElement).icon = 'icons:chevron-right';
+    } else {
+      panel.style.width = '0px';
+      (target as IronIconElement).icon = 'icons:chevron-left';
+    }
+  }
+
+  render() {
+    return html`
+      <div id="container">
+        <div id="panel">
+          <paper-tabs noink>
+            <paper-tab>
+              <iron-icon icon="icons:select-all"></iron-icon>
+            </paper-tab>
+          </paper-tabs>
+          <iron-icon
+            @click=${this.togglePanel}
+            id="toggle-side-panel"
+            icon="icons:chevron-right"
+          ></iron-icon>
+
+          <tab-container title="Shared Widgets">
+            <dropzone-widget></dropzone-widget>
+          </tab-container>
+        </div>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'scratch-panel': ScratchPanel;
+  }
+}

--- a/app-creator/client/src/widgets/scratch-panel/test/scratch-panel_test.ts
+++ b/app-creator/client/src/widgets/scratch-panel/test/scratch-panel_test.ts
@@ -1,0 +1,22 @@
+/**
+ *  @fileoverview This file tests the scratch-panel widget.
+ */
+import { ScratchPanel } from '../scratch-panel';
+import { fixture, html, expect, assert } from '@open-wc/testing';
+
+suite('scratch-panel', () => {
+  test('is defined', () => {
+    const el = document.createElement('scratch-panel');
+    assert.instanceOf(el, ScratchPanel);
+  });
+
+  test('renders widget', async () => {
+    const el = await fixture(html`<scratch-panel></scratch-panel>`);
+    expect(el.shadowRoot!.childNodes.length).to.be.greaterThan(0);
+  });
+
+  test('renders correct tag', async () => {
+    const el = await fixture(html`<scratch-panel></scratch-panel>`);
+    expect(el.tagName).to.equal('SCRATCH-PANEL');
+  });
+});

--- a/app-creator/client/src/widgets/search-bar/search-bar.ts
+++ b/app-creator/client/src/widgets/search-bar/search-bar.ts
@@ -5,6 +5,7 @@
 import { css, customElement, html, LitElement, property } from 'lit-element';
 import { styleMap } from 'lit-html/directives/style-map';
 import { debounce } from '../../utils/debounce';
+import '@polymer/iron-icon/iron-icon';
 
 export interface onSearchEvent {
   detail: {
@@ -22,7 +23,7 @@ export class Searchbar extends LitElement {
   static styles = css`
     #container {
       width: calc(100% - 2 * var(--tight));
-      border: 0.7px solid rgba(0, 0, 0, 0.3);
+      border: 0.7px solid var(--border-gray);
       padding: var(--tight);
       border-radius: var(--regular-border-radius);
       height: 15px;

--- a/app-creator/client/src/widgets/story-board/story-board.ts
+++ b/app-creator/client/src/widgets/story-board/story-board.ts
@@ -16,7 +16,10 @@ import { DeviceType, EventType, Palette } from '../../redux/types/enums';
 import { store } from '../../redux/store';
 import { AppCreatorStore } from '../../redux/reducer';
 import { PaperCardElement } from '@polymer/paper-card/paper-card.js';
-import { generateUI } from '../../utils/template-generation';
+import {
+  generateUI,
+  incrementWidgetIDs,
+} from '../../utils/template-generation';
 import {
   setSelectedTemplateID,
   setEventType,
@@ -185,16 +188,27 @@ export class Storyboard extends connect(store)(LitElement) {
       this.clearSelectedPalette();
 
       this.renderNewTemplate(template);
-    }
-
-    /**
-     * We want to Re-render the storyboard when we switch the template color palette.
-     * We do this by checking if the changingPalette event has been emitted.
-     */
-    if (state.eventType === EventType.changingPalette) {
+    } else if (
+      /**
+       * We want to Re-render the storyboard when we switch the template color palette.
+       * We do this by checking if the changingPalette event has been emitted.
+       */
+      state.eventType === EventType.changingPalette ||
+      state.eventType === EventType.changingTemplate
+    ) {
       store.dispatch(setEventType(EventType.none, true));
 
       this.renderNewTemplate(template);
+
+      try {
+        const template = localStorage.getItem('previousTemplate');
+        if (template) {
+          const widgets = JSON.parse(template).widgets;
+          incrementWidgetIDs(widgets);
+        }
+      } catch (e) {
+        console.error(e);
+      }
     }
   }
 

--- a/app-creator/client/src/widgets/story-board/story-board.ts
+++ b/app-creator/client/src/widgets/story-board/story-board.ts
@@ -120,6 +120,7 @@ export class Storyboard extends connect(store)(LitElement) {
       position: absolute;
       top: -36px;
       right: 0px;
+      margin: var(--tight) 0px;
     }
 
     #select-palette {

--- a/app-creator/client/src/widgets/story-board/story-board.ts
+++ b/app-creator/client/src/widgets/story-board/story-board.ts
@@ -143,7 +143,10 @@ export class Storyboard extends connect(store)(LitElement) {
         <paper-card
           id="storyboard"
           style=${styleMap(styles)}
-          class=${classMap({ storyboard: true, 'mobile-storyboard': isMobile })}
+          class=${classMap({
+            storyboard: !isMobile,
+            'mobile-storyboard': isMobile,
+          })}
         ></paper-card>
       </div>
     `;

--- a/app-creator/client/src/widgets/story-board/story-board.ts
+++ b/app-creator/client/src/widgets/story-board/story-board.ts
@@ -9,8 +9,8 @@ import {
   property,
   query,
 } from 'lit-element';
-import { classMap } from 'lit-html/directives/class-map';
 import { styleMap } from 'lit-html/directives/style-map';
+import { classMap } from 'lit-html/directives/class-map';
 import { connect } from 'pwa-helpers';
 import { DeviceType, EventType, Palette } from '../../redux/types/enums';
 import { store } from '../../redux/store';
@@ -120,7 +120,6 @@ export class Storyboard extends connect(store)(LitElement) {
       position: absolute;
       top: -36px;
       right: 0px;
-      margin: var(--tight) 0px;
     }
 
     #select-palette {
@@ -178,9 +177,8 @@ export class Storyboard extends connect(store)(LitElement) {
      * template id from the current template config.
      */
     if (
-      (template.hasOwnProperty('config') &&
-        template.config.id !== state.selectedTemplateID) ||
-      state.eventType === EventType.changingPalette
+      template.hasOwnProperty('config') &&
+      template.config.id !== state.selectedTemplateID
     ) {
       store.dispatch(setSelectedTemplateID(template.config.id));
 
@@ -198,8 +196,6 @@ export class Storyboard extends connect(store)(LitElement) {
 
       this.renderNewTemplate(template);
     }
-
-    this.requestUpdate();
   }
 
   /**
@@ -245,26 +241,8 @@ export class Storyboard extends connect(store)(LitElement) {
     store.dispatch(setEventType(EventType.changingPalette, true));
   }
 
-  /**
-   * Callback triggered on change palette confirmation dismiss dialog.
-   */
-  handleConfirmationDismiss() {
-    if (this.paletteConfimationDialog) {
-      this.paletteConfimationDialog.close();
-    }
-    if (this.paletteSelect) {
-      this.paletteSelect.value = this.selectedPalette;
-      this.requestedPalette = this.selectedPalette;
-    }
-  }
-
   render() {
-    const {
-      styles,
-      handlePaletteChange,
-      paletteChangeConfirmation,
-      handleConfirmationDismiss,
-    } = this;
+    const { styles, handlePaletteChange, paletteChangeConfirmation } = this;
 
     const isMobile =
       store.getState().template.config?.device === DeviceType.mobile;
@@ -291,7 +269,16 @@ export class Storyboard extends connect(store)(LitElement) {
           Changing the template palette will overwrite any applied styles.
         </p>
         <div class="buttons">
-          <paper-button @click=${handleConfirmationDismiss}
+          <paper-button
+            @click=${() => {
+              if (this.paletteConfimationDialog) {
+                this.paletteConfimationDialog.close();
+              }
+              if (this.paletteSelect) {
+                this.paletteSelect.value = this.selectedPalette;
+                this.requestedPalette = this.selectedPalette;
+              }
+            }}
             >Decline</paper-button
           >
           <paper-button

--- a/app-creator/client/src/widgets/story-board/story-board.ts
+++ b/app-creator/client/src/widgets/story-board/story-board.ts
@@ -12,12 +12,17 @@ import {
 import { styleMap } from 'lit-html/directives/style-map';
 import { classMap } from 'lit-html/directives/class-map';
 import { connect } from 'pwa-helpers';
-import { DeviceType } from '../../redux/types/enums';
+import { DeviceType, EventType, Palette } from '../../redux/types/enums';
 import { store } from '../../redux/store';
 import { AppCreatorStore } from '../../redux/reducer';
 import { PaperCardElement } from '@polymer/paper-card/paper-card.js';
 import { generateUI } from '../../utils/template-generation';
-import { setSelectedTemplateID } from '../../redux/actions';
+import {
+  setSelectedTemplateID,
+  setEventType,
+  setPalette,
+} from '../../redux/actions';
+import { PaperDialogElement } from '@polymer/paper-dialog/paper-dialog';
 import '@polymer/paper-card/paper-card.js';
 import '@polymer/iron-icons/hardware-icons.js';
 import '@polymer/paper-tabs/paper-tabs';
@@ -25,6 +30,7 @@ import '@polymer/paper-tabs/paper-tab';
 import '../dropzone-widget/dropzone-widget';
 import '../ui-map/ui-map';
 import '../ui-panel/ui-panel';
+import '@polymer/paper-dialog/paper-dialog';
 
 const STORYBOARD_ID = 'storyboard';
 
@@ -35,31 +41,35 @@ const STORYBOARD_ID = 'storyboard';
 @customElement('story-board')
 export class Storyboard extends connect(store)(LitElement) {
   static styles = css`
-    #container {
+    .container {
       height: 100%;
       width: 100%;
       display: flex;
       flex-direction: column;
       align-items: center;
       justify-content: center;
+      position: relative;
+      transition: 0.5s ease;
+      max-height: 95%;
+    }
+
+    .mobile-container {
+      height: 600px;
+      width: 350px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      position: relative;
+      margin: 0 auto;
+      transition: 0.5s ease;
     }
 
     .storyboard {
       height: 100%;
       width: 100%;
       background-color: var(--primary-color);
-      margin: 0 auto;
       overflow: hidden;
-      transition: 0.5s ease;
-    }
-
-    .mobile-storyboard {
-      height: 700px;
-      width: 350px;
-      background-color: var(--primary-color);
-      margin: 0 auto;
-      overflow: hidden;
-      transition: 0.5s ease;
     }
 
     #root-panel {
@@ -102,25 +112,30 @@ export class Storyboard extends connect(store)(LitElement) {
       width: 150px;
       margin: var(--regular) auto var(--tight) auto;
     }
-  `;
 
-  stateChanged(state: AppCreatorStore) {
-    const template = state.template;
-    if (
-      template.hasOwnProperty('config') &&
-      template.config.id !== state.selectedTemplateID
-    ) {
-      store.dispatch(setSelectedTemplateID(template.config.id));
-
-      const { storyboard } = this;
-      if (storyboard) {
-        storyboard.innerHTML = ``;
-        generateUI(template, storyboard);
-      }
-
-      this.requestUpdate();
+    #palette-select-container {
+      display: flex;
+      justify-content: flex-end;
+      width: 100%;
+      position: absolute;
+      top: -36px;
+      right: 0px;
     }
-  }
+
+    #select-palette {
+      padding: var(--extra-tight);
+      border-radius: var(--extra-tight);
+      background-color: white;
+    }
+
+    paper-button {
+      color: var(--accent-color);
+    }
+
+    #palette-change-confirmation-dialog {
+      border-radius: var(--tight);
+    }
+  `;
 
   /**
    * Additional custom styles.
@@ -128,26 +143,168 @@ export class Storyboard extends connect(store)(LitElement) {
   @property({ type: Object }) styles = {};
 
   /**
+   * Used for setting template palette.
+   */
+  @property({ type: String }) selectedPalette: Palette = Palette.light;
+
+  /**
+   * Used for temporarily storing requested palette. This is required because we want
+   * to rollback to the old palette if the user declines the confirmation dialog.
+   */
+  @property({ type: String }) requestedPalette: Palette = Palette.light;
+
+  /**
    * Reference to storyboard element.
    */
   @query(`#${STORYBOARD_ID}`) storyboard!: PaperCardElement;
 
+  /**
+   * Reference to paper dialog modal.
+   */
+  @query('paper-dialog') paletteConfimationDialog!: PaperDialogElement;
+
+  /**
+   * Reference to palette select input element.
+   */
+  @query('#select-palette') paletteSelect!: HTMLSelectElement;
+
+  stateChanged(state: AppCreatorStore) {
+    const template = state.template;
+
+    /**
+     * Re-render storyboard when switching between templates. We check if
+     * the selectedTemplateID property on the store is the same as the
+     * template id from the current template config.
+     */
+    if (
+      template.hasOwnProperty('config') &&
+      template.config.id !== state.selectedTemplateID
+    ) {
+      store.dispatch(setSelectedTemplateID(template.config.id));
+
+      this.clearSelectedPalette();
+
+      this.renderNewTemplate(template);
+    }
+
+    /**
+     * We want to Re-render the storyboard when we switch the template color palette.
+     * We do this by checking if the changingPalette event has been emitted.
+     */
+    if (state.eventType === EventType.changingPalette) {
+      store.dispatch(setEventType(EventType.none, true));
+
+      this.renderNewTemplate(template);
+    }
+  }
+
+  /**
+   * Clears the value of the palette select input and restores initial state.
+   */
+  clearSelectedPalette() {
+    if (this.paletteSelect) {
+      this.paletteSelect.value = '';
+    }
+    this.selectedPalette = Palette.light;
+    this.requestedPalette = Palette.light;
+  }
+
+  /**
+   * Renders new template by calling generateUI and requesting update.
+   */
+  renderNewTemplate(template: AppCreatorStore['template']) {
+    const { storyboard } = this;
+    if (storyboard) {
+      storyboard.innerHTML = ``;
+      generateUI(template, storyboard);
+    }
+
+    this.requestUpdate();
+  }
+
+  /**
+   * Sets the selected palette in state and opens the confirmation dialog.
+   */
+  handlePaletteChange(e: Event) {
+    this.requestedPalette = (e.target as HTMLSelectElement).value as Palette;
+    if (this.paletteConfimationDialog) {
+      this.paletteConfimationDialog.open();
+    }
+  }
+
+  /**
+   * Called when users confirm on the confirmation dialog when changing palettes.
+   */
+  paletteChangeConfirmation() {
+    this.selectedPalette = this.requestedPalette;
+    store.dispatch(setPalette(this.selectedPalette));
+    store.dispatch(setEventType(EventType.changingPalette, true));
+  }
+
   render() {
-    const { styles } = this;
+    const { styles, handlePaletteChange, paletteChangeConfirmation } = this;
 
     const isMobile =
       store.getState().template.config?.device === DeviceType.mobile;
 
+    const paletteSelectInput = html`
+      <div id="palette-select-container">
+        <select
+          name="Select palette"
+          id="select-palette"
+          @change=${handlePaletteChange}
+        >
+          <option value="" disabled selected>Change Palette</option>
+          ${Object.keys(Palette).map(
+            (palette) => html`<option value=${palette}>${palette}</option>`
+          )}
+        </select>
+      </div>
+    `;
+
+    const paletteChangeConfirmationDialog = html`
+      <paper-dialog with-backdrop id="palette-change-confirmation-dialog">
+        <h2>Are you sure you?</h2>
+        <p>
+          Changing the template palette will overwrite any applied styles.
+        </p>
+        <div class="buttons">
+          <paper-button
+            @click=${() => {
+              if (this.paletteConfimationDialog) {
+                this.paletteConfimationDialog.close();
+              }
+              if (this.paletteSelect) {
+                this.paletteSelect.value = this.selectedPalette;
+                this.requestedPalette = this.selectedPalette;
+              }
+            }}
+            >Decline</paper-button
+          >
+          <paper-button
+            dialog-confirm
+            autofocus
+            @click=${paletteChangeConfirmation}
+            >Accept</paper-button
+          >
+        </div>
+      </paper-dialog>
+    `;
+
     return html`
-      <div id="container">
+      <div
+        class=${classMap({
+          'mobile-container': isMobile,
+          container: !isMobile,
+        })}
+      >
+        ${paletteSelectInput}
         <paper-card
           id="storyboard"
           style=${styleMap(styles)}
-          class=${classMap({
-            storyboard: !isMobile,
-            'mobile-storyboard': isMobile,
-          })}
+          class="storyboard"
         ></paper-card>
+        ${paletteChangeConfirmationDialog}
       </div>
     `;
   }

--- a/app-creator/client/src/widgets/template-card/template-card.ts
+++ b/app-creator/client/src/widgets/template-card/template-card.ts
@@ -3,10 +3,10 @@
  */
 import { LitElement, html, customElement, css, property } from 'lit-element';
 import { nothing } from 'lit-html';
-import '@polymer/paper-card/paper-card.js';
-import '@polymer/paper-button/paper-button.js';
 import { noop } from '../../utils/helpers';
 import { store } from '../../redux/store';
+import '@polymer/paper-card/paper-card.js';
+import '@polymer/paper-button/paper-button.js';
 
 @customElement('template-card')
 export class TemplateCard extends LitElement {

--- a/app-creator/client/src/widgets/template-card/template-card.ts
+++ b/app-creator/client/src/widgets/template-card/template-card.ts
@@ -4,7 +4,6 @@
 import { LitElement, html, customElement, css, property } from 'lit-element';
 import { nothing } from 'lit-html';
 import { noop } from '../../utils/helpers';
-import { store } from '../../redux/store';
 import '@polymer/paper-card/paper-card.js';
 import '@polymer/paper-button/paper-button.js';
 
@@ -70,8 +69,7 @@ export class TemplateCard extends LitElement {
   @property({ type: Boolean }) showTitle = false;
 
   render() {
-    const { id, imageUrl, title, showTitle, onSelection } = this;
-    const selected = store.getState().template.config?.parentID === id;
+    const { imageUrl, title, showTitle, selected, onSelection } = this;
     const buttonLabel = selected ? 'Selected' : 'Select';
 
     const titleMarkup = showTitle ? html`<h4>${title}</h4>` : nothing;

--- a/app-creator/client/src/widgets/template-wizard/template-wizard.ts
+++ b/app-creator/client/src/widgets/template-wizard/template-wizard.ts
@@ -1,0 +1,614 @@
+/**
+ * @fileoverview The template wizard widget allows the user to select their desired configuration setting and select a particular template.
+ */
+import {
+  customElement,
+  LitElement,
+  css,
+  property,
+  query,
+  html,
+} from 'lit-element';
+import { nothing, TemplateResult } from 'lit-html';
+import { DeviceType, Palette } from '../../redux/types/enums';
+import { TemplateItem } from '../../client/fetch-templates';
+import { PaperDialogElement } from '@polymer/paper-dialog';
+import { templatesManager } from '../../data/templates';
+import { PaperToastElement } from '@polymer/paper-toast';
+import { TemplatesTabItem, TemplatesTab } from '../templates-tab/templates-tab';
+import { onSearchEvent } from '../search-bar/search-bar';
+import { generateRandomId } from '../../utils/helpers';
+import { palette } from '../../utils/palettes';
+import '@polymer/paper-progress/paper-progress';
+import '@cwmr/paper-chip/paper-chip.js';
+import { store } from '../../redux/store';
+import { setSelectedTemplate } from '../../redux/actions';
+
+@customElement('template-wizard')
+export class TemplateWizard extends LitElement {
+  static styles = css`
+    #cards-container {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      width: 100%;
+      margin-top: var(--regular);
+      height: 300px;
+      overflow-y: scroll;
+    }
+
+    template-card {
+      width: 200px;
+      margin: var(--regular);
+    }
+
+    paper-dialog {
+      width: 800px;
+      height: 500px;
+      border-radius: var(--tight);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      overflow-y: scroll;
+    }
+
+    #header-content {
+      width: 400px;
+      margin: 0 auto;
+    }
+
+    .subtitle {
+      margin: 0;
+      font-size: 1rem;
+      color: var(--accent-color);
+      font-weight: 500;
+    }
+
+    #modal-title {
+      text-align: center;
+      color: var(--accent-color);
+    }
+
+    paper-progress {
+      width: 100%;
+      height: 20px;
+      z-index: 10;
+      position: absolute;
+      top: 0;
+      left: 0;
+      margin: 0px;
+    }
+
+    #chips-container {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      justify-content: center;
+      margin-top: var(--tight);
+    }
+
+    paper-chip {
+      margin: 0px var(--extra-tight);
+      background-color: var(--primary-color);
+      color: var(--accent-color);
+    }
+
+    .selected-paper-chip {
+      background-color: var(--accent-color);
+      color: var(--primary-color);
+    }
+
+    #content-body {
+      padding: 0px;
+      margin: 0px;
+      width: 100%;
+      height: 90%;
+    }
+
+    #configuration-form {
+      display: flex;
+      flex-direction: column;
+      width: 30%;
+      border-right: var(--light-border);
+      align-items: center;
+      padding: var(--tight);
+      height: 100%;
+    }
+
+    #template-selection {
+      width: 70%;
+      height: 100%;
+      padding: var(--tight);
+      overflow: hidden;
+    }
+
+    #button-container {
+      width: 100%;
+      height: 10%;
+      padding: 0px;
+      margin: 0px;
+      display: flex;
+      justify-content: flex-end;
+      align-items: center;
+      border-top: var(--light-border);
+    }
+
+    paper-button {
+      background-color: var(--accent-color);
+      color: var(--primary-color);
+      height: 30px;
+      font-size: 0.8rem;
+      margin-right: var(--regular);
+    }
+
+    .input-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .input-label {
+      margin: 0px 0px;
+      font-size: 0.7rem;
+      font-weight: 600;
+      color: var(--accent-color);
+    }
+
+    input {
+      margin: var(--tight) 0px;
+    }
+
+    .config-input-container {
+      margin: var(--extra-tight) 0px;
+      margin-right: 0px;
+      width: 90%;
+    }
+
+    .config-input {
+      border: var(--light-border);
+      padding: var(--extra-tight);
+      -webkit-border-radius: var(--extra-tight);
+      border-radius: var(--extra-tight);
+      width: 100%;
+      resize: none;
+      font-family: inherit;
+      background-color: var(--primary-color);
+      margin: var(--extra-tight) 0px;
+    }
+
+    .config-input:focus {
+      border-color: var(--accent-color);
+      outline: none;
+    }
+
+    .config-select-input {
+      width: 94%;
+    }
+
+    .row {
+      display: flex;
+      height: 100%;
+      overflow: hidden;
+    }
+
+    .form-inputs {
+      width: 100%;
+      padding: var(--tight);
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      margin: 0 auto;
+    }
+
+    .disabled-button {
+      opacity: 0.5;
+    }
+  `;
+
+  /**
+   * Sets template dialog search query.
+   */
+  @property({ type: String }) query = '';
+
+  /**
+   * Sets device filter.
+   */
+  @property({ type: String }) deviceFilter: DeviceType = DeviceType.all;
+
+  /**
+   * Array of templates.
+   */
+  @property({ type: Array }) templates: TemplateItem[] = [];
+
+  /**
+   * Loading state.
+   */
+  @property({ type: Boolean }) loading = false;
+
+  /**
+   * Reference to dialog element.
+   */
+  @query('paper-dialog') dialog!: PaperDialogElement;
+
+  /**
+   * Reference to dialog element.
+   */
+  @query('#template-parsing-error') parsingErrorToast!: PaperToastElement;
+
+  /**
+   * ID of the currently selected template.
+   */
+  @property({ type: String }) selectedTemplateID = '';
+
+  /**
+   * Configuration object that stores metadata about a template.
+   */
+  @property({ type: Object }) config: { [key: string]: string } = {
+    id: generateRandomId(),
+    name: '',
+    palette: Palette.light,
+  };
+
+  async firstUpdated() {
+    try {
+      this.loading = true;
+
+      const templates = await templatesManager.fetchTemplates(false);
+      if (templates != null) {
+        this.templates = templates;
+      }
+    } catch (e) {
+      const fetchErrorToast = this.shadowRoot?.getElementById(
+        'fetch-error-toast'
+      ) as PaperToastElement;
+
+      if (fetchErrorToast != null) {
+        fetchErrorToast.open();
+      }
+      this.templates = templatesManager.getTemplates();
+    } finally {
+      this.loading = false;
+    }
+    this.showTemplateSelectionModal();
+  }
+
+  showTemplateSelectionModal() {
+    this.dialog.open();
+  }
+
+  /**
+   * Used for filtering templates.
+   */
+  handleDeviceFilters(device: DeviceType) {
+    this.deviceFilter = device;
+  }
+
+  /**
+   * Generates an input header for each setting input.
+   */
+  getInputHeader(title: string) {
+    return html`
+      <div class="input-header">
+        <p class="input-label">${title}</p>
+      </div>
+    `;
+  }
+
+  /**
+   * Sets currently selected template id.
+   */
+  handleTemplateSelection(id: string) {
+    this.selectedTemplateID = id;
+  }
+
+  /**
+   * Returns array of template cards.
+   */
+  getTemplateCards(showTitle = false): Array<TemplatesTabItem> {
+    return this.templates.map(({ id, name, imageUrl, device }) => {
+      return {
+        id,
+        name,
+        device,
+        markup: html`
+          ${showTitle ? nothing : html`<h6 class="subtitle">${name}</h6>`}
+          <template-card
+            id="${id}"
+            title="${name}"
+            imageUrl="${imageUrl}"
+            ?selected=${this.selectedTemplateID === id}
+            ?showTitle=${showTitle}
+            .onSelection=${() => this.handleTemplateSelection(id)}
+          ></template-card>
+        `,
+      };
+    });
+  }
+
+  /**
+   * Sets the query property when an onsearch event is dispatched from the
+   * searchbar widget.
+   */
+  handleSearch({ detail: { query } }: onSearchEvent) {
+    this.query = query.trim();
+  }
+
+  /**
+   * Creates a text input element.
+   */
+  getTextInput(
+    title: string,
+    value: string,
+    placeholder: string,
+    key: string,
+    disabled: boolean,
+    required?: boolean
+  ): TemplateResult {
+    return html`
+    <div class="config-input-container">
+        ${this.getInputHeader(title)}
+        <input
+            class='config-input text-input'
+            placeholder=${placeholder}
+            @keyup=${(e: Event) => {
+              this.config[key] = (e.target as HTMLInputElement).value;
+              this.requestUpdate();
+            }}
+            ?disabled=${disabled}
+            ?required=${required}
+            value=${value}
+        ></input>
+    </div>
+    `;
+  }
+
+  /**
+   * Creates a select input element.
+   */
+  getSelectInput(
+    key: string,
+    title: string,
+    value: string,
+    items: string[]
+  ): TemplateResult | {} {
+    if (items == null) {
+      return nothing;
+    }
+    const optionList = [];
+    for (const item of items) {
+      optionList.push(html`<option value="${item}" ?selected=${item === value}
+        >${item}</option
+      >`);
+    }
+
+    return html`
+      <div class="config-input-container config-select-input">
+        ${this.getInputHeader(title)}
+        <select
+          name="${title}"
+          class="config-input"
+          .value="${this.config[key]}"
+          @change=${(e: Event) => {
+            this.config[key] = (e.target as HTMLSelectElement).value;
+          }}
+        >
+          ${optionList}
+        </select>
+      </div>
+    `;
+  }
+
+  /**
+   * Takes in a template object and applies a selected color palette to it.
+   */
+  applyConfiguration(template: any, color: Palette) {
+    const widgets = template.widgets;
+    for (const widgetID in widgets) {
+      // Set the background color of panel elements. None panel elements start with a transparent background.
+      if (
+        widgetID.startsWith('panel') ||
+        widgetID.startsWith('button') ||
+        widgetID.startsWith('sidemenu')
+      ) {
+        widgets[widgetID].style.backgroundColor =
+          palette[color].backgroundColor;
+      }
+
+      // Apply color property on none panel elements.
+      if (!widgetID.startsWith('panel')) {
+        widgets[widgetID].style.color = palette[color].color;
+      }
+
+      // Apply map styling.
+      if (widgetID.startsWith('map')) {
+        widgets[widgetID].uniqueAttributes.mapStyles = palette[color].map;
+      }
+    }
+  }
+
+  /**
+   * Callback triggered on continue button click.
+   */
+  handleContinueClick() {
+    try {
+      // Get template from database.
+      const template = templatesManager
+        .getTemplates()
+        .find(({ id }) => id === this.selectedTemplateID)?.template;
+
+      if (template) {
+        // Parse template and apply configuration properties.
+        const templateJSON = JSON.parse(template);
+        templateJSON.config['id'] = this.config.id;
+        templateJSON.config['name'] = this.config.name;
+        this.applyConfiguration(
+          templateJSON,
+          this.config.palette.toLowerCase() as Palette
+        );
+
+        // Set new template in store.
+        store.dispatch(setSelectedTemplate(templateJSON));
+
+        // Close dialog.
+        const { dialog } = this;
+        if (dialog != null) {
+          dialog.close();
+        }
+      }
+    } catch (e) {
+      if (this.parsingErrorToast) {
+        this.parsingErrorToast.open();
+      }
+    }
+  }
+
+  render() {
+    const {
+      handleSearch,
+      getTemplateCards,
+      handleDeviceFilters,
+      handleContinueClick,
+      deviceFilter,
+      query,
+      loading,
+    } = this;
+
+    /**
+     * Get a list of template cards.
+     */
+    const templateCards = getTemplateCards.call(this, true);
+    const filteredTemplates = TemplatesTab.filterTemplates(
+      templateCards,
+      query,
+      deviceFilter
+    );
+
+    const emptyNotice = html`
+      <empty-notice
+        id="empty-notice"
+        icon="search"
+        message='No templates match "${query}". Please search again.'
+        size="large"
+        bold
+      ></empty-notice>
+    `;
+
+    const contentMarkup = loading
+      ? nothing
+      : html`
+          <div id="cards-container">
+            ${filteredTemplates.map(({ markup }) => markup)}
+            ${filteredTemplates.length === 0 ? emptyNotice : nothing}
+          </div>
+        `;
+
+    const loadingBar = loading
+      ? html`<paper-progress indeterminate></paper-progress>`
+      : nothing;
+
+    const sortingChips = html`
+      <div id="chips-container">
+        <paper-chip
+          selectable
+          class="${this.deviceFilter === DeviceType.all
+            ? 'selected-paper-chip'
+            : ''}"
+          @click=${() => handleDeviceFilters.call(this, DeviceType.all)}
+          >All</paper-chip
+        >
+        <paper-chip
+          selectable
+          class="${this.deviceFilter === DeviceType.desktop
+            ? 'selected-paper-chip'
+            : ''}"
+          @click=${() => handleDeviceFilters.call(this, DeviceType.desktop)}
+          >Web</paper-chip
+        ><paper-chip
+          selectable
+          class="${this.deviceFilter === DeviceType.mobile
+            ? 'selected-paper-chip'
+            : ''}"
+          @click=${() => handleDeviceFilters.call(this, DeviceType.mobile)}
+          >Mobile</paper-chip
+        >
+      </div>
+    `;
+
+    const configurationForm = html`
+      <div id="configuration-form">
+        <h3>Settings</h3>
+        <div class="form-inputs">
+          ${this.getTextInput(
+            'Template Name:',
+            this.config.name,
+            'Enter Name',
+            'name',
+            false,
+            true
+          )}
+          ${this.getSelectInput(
+            'palette',
+            'Palette',
+            this.config.palette,
+            Object.keys(Palette).map(
+              (palette) => palette[0].toUpperCase() + palette.slice(1)
+            )
+          )}
+        </div>
+      </div>
+    `;
+
+    const templateSelection = html`
+      <div id="template-selection">
+        <div id="header-content">
+          <h3 id="modal-title">Template Selection</h3>
+          <search-bar
+            placeholder="Search for template (i.e. side panel)"
+            @onsearch=${handleSearch}
+          ></search-bar>
+          ${sortingChips}
+        </div>
+        ${contentMarkup}
+      </div>
+    `;
+
+    const validForm = this.config.name !== '' && this.selectedTemplateID !== '';
+
+    const disabledClass = validForm ? '' : 'disabled-button';
+
+    return html`
+      <paper-dialog with-backdrop no-cancel-on-outside-click>
+        ${loadingBar}
+        <div id="content-body">
+          <div class="row">
+            ${configurationForm} ${templateSelection}
+          </div>
+          <div id="button-container">
+            <paper-button
+              class="${disabledClass}"
+              ?disabled=${!validForm}
+              @click=${handleContinueClick}
+              >Continue</paper-button
+            >
+          </div>
+        </div>
+      </paper-dialog>
+
+      <paper-toast
+        id="fetch-error-toast"
+        text="Unable to fetch the latest templates from the server."
+      ></paper-toast>
+
+      <paper-toast
+        id="template-parsing-error"
+        text="Template parsing failed."
+      ></paper-toast>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'template-wizard': TemplateWizard;
+  }
+}

--- a/app-creator/client/src/widgets/template-wizard/template-wizard.ts
+++ b/app-creator/client/src/widgets/template-wizard/template-wizard.ts
@@ -238,14 +238,14 @@ export class TemplateWizard extends LitElement {
   /**
    * ID of the currently selected template.
    */
-  @property({ type: String }) selectedTemplateID = '';
+  @property({ type: String }) selectedTemplateID = 'left-side-panel';
 
   /**
    * Configuration object that stores metadata about a template.
    */
   @property({ type: Object }) config: { [key: string]: string } = {
     id: generateRandomId(),
-    name: '',
+    name: 'test app',
     palette: Palette.light,
   };
 

--- a/app-creator/client/src/widgets/template-wizard/template-wizard.ts
+++ b/app-creator/client/src/widgets/template-wizard/template-wizard.ts
@@ -19,10 +19,11 @@ import { TemplatesTabItem, TemplatesTab } from '../templates-tab/templates-tab';
 import { onSearchEvent } from '../search-bar/search-bar';
 import { generateRandomId } from '../../utils/helpers';
 import { palette } from '../../utils/palettes';
-import '@polymer/paper-progress/paper-progress';
-import '@cwmr/paper-chip/paper-chip.js';
 import { store } from '../../redux/store';
 import { setSelectedTemplate } from '../../redux/actions';
+import { transferData } from '../../utils/template-generation';
+import '@polymer/paper-progress/paper-progress';
+import '@cwmr/paper-chip/paper-chip.js';
 
 @customElement('template-wizard')
 export class TemplateWizard extends LitElement {
@@ -448,6 +449,8 @@ export class TemplateWizard extends LitElement {
 
         // Set new template in store.
         store.dispatch(setSelectedTemplate(templateJSON));
+
+        transferData();
 
         // Close dialog.
         const { dialog } = this;

--- a/app-creator/client/src/widgets/template-wizard/test/template-wizard_test.ts
+++ b/app-creator/client/src/widgets/template-wizard/test/template-wizard_test.ts
@@ -1,0 +1,22 @@
+/**
+ *  @fileoverview This file tests the template-wizard widget.
+ */
+import { TemplateWizard } from '../template-wizard';
+import { fixture, html, expect, assert } from '@open-wc/testing';
+
+suite('templates-tab', () => {
+  test('is defined', () => {
+    const el = document.createElement('template-wizard');
+    assert.instanceOf(el, TemplateWizard);
+  });
+
+  test('renders widget', async () => {
+    const el = await fixture(html`<template-wizard></template-wizard>`);
+    expect(el.shadowRoot!.childNodes.length).to.be.greaterThan(0);
+  });
+
+  test('renders correct tag', async () => {
+    const el = await fixture(html`<template-wizard></template-wizard>`);
+    expect(el.tagName).to.equal('TEMPLATE-WIZARD');
+  });
+});

--- a/app-creator/client/src/widgets/templates-tab/templates-tab.ts
+++ b/app-creator/client/src/widgets/templates-tab/templates-tab.ts
@@ -104,6 +104,7 @@ export class TemplatesTab extends connect(store)(LitElement) {
             title="${name}"
             imageUrl="${imageUrl}"
             ?showTitle=${showTitle}
+            ?selected=${store.getState().template.config.parentID === id}
             .onSelection=${this.createSelectionCallback(template)}
           ></template-card>
         `,

--- a/app-creator/client/src/widgets/templates-tab/templates-tab.ts
+++ b/app-creator/client/src/widgets/templates-tab/templates-tab.ts
@@ -1,17 +1,30 @@
 /**
  *  @fileoverview The templates-tab widget contains the different templates that the user can use for their earth engine app.
  */
-import { LitElement, html, customElement, css, property } from 'lit-element';
+import {
+  LitElement,
+  html,
+  customElement,
+  css,
+  property,
+  query,
+} from 'lit-element';
 import { nothing, TemplateResult } from 'lit-html';
 import { onSearchEvent } from '../search-bar/search-bar';
 import { store } from '../../redux/store';
-import { setSelectedTemplate } from '../../redux/actions';
+import {
+  setSelectedTemplate,
+  updateWidgetMetaData,
+  addWidgetMetaData,
+  updateWidgetChildren,
+  setEventType,
+} from '../../redux/actions';
 import { templatesManager } from '../../data/templates';
 import { connect } from 'pwa-helpers';
-import { AppCreatorStore } from '../../redux/reducer';
-import { DeviceType } from '../../redux/types/enums';
+import { AppCreatorStore, WidgetMetaData } from '../../redux/reducer';
+import { DeviceType, EventType } from '../../redux/types/enums';
 import { classMap } from 'lit-html/directives/class-map';
-import { chips } from '../../utils/helpers';
+import { chips, deepCloneTemplate } from '../../utils/helpers';
 import '@polymer/paper-input/paper-input.js';
 import '@polymer/iron-icon/iron-icon.js';
 import '../tab-container/tab-container';
@@ -28,6 +41,9 @@ import '../search-bar/search-bar';
 import '../empty-notice/empty-notice';
 import '../template-card/template-card';
 import '@cwmr/paper-chip/paper-chip.js';
+import { PaperDialogElement } from '@polymer/paper-dialog';
+import { ROOT_ID } from '../../utils/constants';
+import { getWidgetElement } from '../../utils/template-generation';
 
 export interface TemplatesTabItem {
   id: string;
@@ -66,6 +82,14 @@ export class TemplatesTab extends connect(store)(LitElement) {
       background-color: var(--accent-color);
       color: var(--primary-color);
     }
+
+    paper-button {
+      color: var(--accent-color);
+    }
+
+    #template-change-confirmation-dialog {
+      border-radius: var(--tight);
+    }
   `;
 
   stateChanged(state: AppCreatorStore) {
@@ -81,6 +105,11 @@ export class TemplatesTab extends connect(store)(LitElement) {
   @property({ type: String }) selectedTemplateID: string = '';
 
   /**
+   * ID of template to be selected.
+   */
+  @property({ type: String }) requestedTemplateID: string = '';
+
+  /**
    * Sets the search query.
    */
   @property({ type: String }) query = '';
@@ -90,27 +119,11 @@ export class TemplatesTab extends connect(store)(LitElement) {
    */
   @property({ type: String }) deviceFilter = DeviceType.all;
 
-  getTemplateCards(showTitle = false) {
-    const templates = templatesManager.getTemplates();
-    return templates.map(({ id, name, imageUrl, device, template }) => {
-      return {
-        id,
-        name,
-        device,
-        markup: html`
-          ${showTitle ? nothing : html`<h6 class="subtitle">${name}</h6>`}
-          <template-card
-            id="${id}"
-            title="${name}"
-            imageUrl="${imageUrl}"
-            ?showTitle=${showTitle}
-            ?selected=${store.getState().template.config.parentID === id}
-            .onSelection=${this.createSelectionCallback(template)}
-          ></template-card>
-        `,
-      };
-    });
-  }
+  /**
+   * Reference to template change confirmation dialog.
+   */
+  @query('#template-change-confirmation-dialog')
+  templateChangeConfirmationDialog!: PaperDialogElement;
 
   /**
    * Returns widgets with names and ids that include the search query.
@@ -135,11 +148,41 @@ export class TemplatesTab extends connect(store)(LitElement) {
     });
   }
 
-  createSelectionCallback(template: string): VoidFunction {
+  /**
+   * Callback triggered on template card selection.
+   */
+  handleTemplateCardSelection(id: string) {
     return () => {
-      store.dispatch(setSelectedTemplate(JSON.parse(template)));
-      this.requestUpdate();
+      this.requestedTemplateID = id;
+      if (this.templateChangeConfirmationDialog) {
+        this.templateChangeConfirmationDialog.open();
+      }
     };
+  }
+
+  /**
+   * Returns a list template card instances that the user can switch to.
+   */
+  getTemplateCards(showTitle = false) {
+    const templates = templatesManager.getTemplates();
+    return templates.map(({ id, name, imageUrl, device }) => {
+      return {
+        id,
+        name,
+        device,
+        markup: html`
+          ${showTitle ? nothing : html`<h6 class="subtitle">${name}</h6>`}
+          <template-card
+            id="${id}"
+            title="${name}"
+            imageUrl="${imageUrl}"
+            ?showTitle=${showTitle}
+            ?selected=${store.getState().template.config.parentID === id}
+            .onSelection=${this.handleTemplateCardSelection(id)}
+          ></template-card>
+        `,
+      };
+    });
   }
 
   /**
@@ -150,8 +193,99 @@ export class TemplatesTab extends connect(store)(LitElement) {
     this.query = query.trim();
   }
 
-  handleDeviceFilters(device: DeviceType) {
-    this.deviceFilter = device;
+  /**
+   * Callback triggered on template change dismiss.
+   */
+  handleTemplateChangeDismiss() {
+    this.requestedTemplateID = '';
+    if (this.templateChangeConfirmationDialog) {
+      this.templateChangeConfirmationDialog.close();
+    }
+  }
+
+  /**
+   * Callback triggered on template change confirmation.
+   */
+  handleTemplateChangeConfirmation() {
+    const template = templatesManager
+      .getTemplates()
+      .find(({ id }) => id === this.requestedTemplateID)?.template;
+
+    if (template) {
+      try {
+        // Saving current template string in localStorage so we can transfer data across.
+        const currentTemplate = JSON.stringify(
+          deepCloneTemplate(store.getState().template)
+        );
+        localStorage.setItem('previousTemplate', currentTemplate);
+
+        // Replace the redux store with the new template and trigger a re-render.
+        const templateJSON = JSON.parse(template);
+        store.dispatch(setSelectedTemplate(templateJSON));
+
+        this.transferData();
+      } catch (e) {
+        console.error(e);
+      }
+    }
+
+    if (this.templateChangeConfirmationDialog) {
+      this.templateChangeConfirmationDialog.close();
+    }
+
+    this.requestUpdate();
+  }
+
+  /**
+   * Retrieves previous template from store and populates user added widgets.
+   */
+  transferData() {
+    try {
+      const template = localStorage.getItem('previousTemplate');
+
+      if (template) {
+        const widgets = JSON.parse(template).widgets;
+        const panelIDs = [];
+
+        // Get all panels that are not the root and that exists in the new and old template.
+        for (const widgetID in widgets) {
+          if (
+            widgetID !== ROOT_ID &&
+            (widgetID.startsWith('panel') || widgetID.startsWith('sidemenu')) &&
+            store.getState().template.widgets.hasOwnProperty(widgetID)
+          ) {
+            panelIDs.push(widgetID);
+          }
+        }
+
+        /**
+         * Populating store with widgets that share the same IDs.
+         */
+        for (const panelID of panelIDs) {
+          for (const child of widgets[panelID].children) {
+            const childMetaData: WidgetMetaData = widgets[child];
+            const { id, uniqueAttributes, style } = childMetaData;
+
+            const { element } = getWidgetElement(childMetaData);
+            const newID = id.split('-').join('-template-');
+            store.dispatch(
+              addWidgetMetaData(newID, element, uniqueAttributes, style)
+            );
+
+            store.dispatch(
+              updateWidgetChildren(panelID, [
+                ...store.getState().template.widgets[panelID].children,
+                newID,
+              ])
+            );
+          }
+        }
+
+        store.dispatch(setEventType(EventType.changingPalette, true));
+      }
+    } catch (e) {
+      throw e;
+    }
   }
 
   render() {
@@ -194,6 +328,25 @@ export class TemplatesTab extends connect(store)(LitElement) {
       </div>
     `;
 
+    const templateChangeConfirmationDialog = html`
+      <paper-dialog with-backdrop id="template-change-confirmation-dialog">
+        <h2>Are you sure you?</h2>
+        <p>
+          Changing templates will discard any applied styles or layouts.
+        </p>
+        <div class="buttons">
+          <paper-button @click=${this.handleTemplateChangeDismiss}
+            >Decline</paper-button
+          >
+          <paper-button
+            @click=${this.handleTemplateChangeConfirmation}
+            autofocus
+            >Accept</paper-button
+          >
+        </div>
+      </paper-dialog>
+    `;
+
     return html`
       <tab-container title="Templates">
         <search-bar
@@ -205,6 +358,7 @@ export class TemplatesTab extends connect(store)(LitElement) {
           ${filteredTemplates.map(({ markup }) => markup)}
           ${filteredTemplates.length === 0 ? emptyNotice : nothing}
         </div>
+        ${templateChangeConfirmationDialog}
       </tab-container>
     `;
   }

--- a/app-creator/client/src/widgets/templates-tab/templates-tab.ts
+++ b/app-creator/client/src/widgets/templates-tab/templates-tab.ts
@@ -11,6 +11,7 @@ import { connect } from 'pwa-helpers';
 import { AppCreatorStore } from '../../redux/reducer';
 import { DeviceType } from '../../redux/types/enums';
 import { classMap } from 'lit-html/directives/class-map';
+import { chips } from '../../utils/helpers';
 import '@polymer/paper-input/paper-input.js';
 import '@polymer/iron-icon/iron-icon.js';
 import '../tab-container/tab-container';
@@ -27,7 +28,6 @@ import '../search-bar/search-bar';
 import '../empty-notice/empty-notice';
 import '../template-card/template-card';
 import '@cwmr/paper-chip/paper-chip.js';
-import { chips } from '../../utils/helpers';
 
 export interface TemplatesTabItem {
   id: string;

--- a/app-creator/client/src/widgets/templates-tab/templates-tab.ts
+++ b/app-creator/client/src/widgets/templates-tab/templates-tab.ts
@@ -3,6 +3,14 @@
  */
 import { LitElement, html, customElement, css, property } from 'lit-element';
 import { nothing, TemplateResult } from 'lit-html';
+import { onSearchEvent } from '../search-bar/search-bar';
+import { store } from '../../redux/store';
+import { setSelectedTemplate } from '../../redux/actions';
+import { templatesManager } from '../../data/templates';
+import { connect } from 'pwa-helpers';
+import { AppCreatorStore } from '../../redux/reducer';
+import { DeviceType } from '../../redux/types/enums';
+import { classMap } from 'lit-html/directives/class-map';
 import '@polymer/paper-input/paper-input.js';
 import '@polymer/iron-icon/iron-icon.js';
 import '../tab-container/tab-container';
@@ -17,18 +25,15 @@ import '../ui-panel/ui-panel';
 import '../ui-chart/ui-chart';
 import '../search-bar/search-bar';
 import '../empty-notice/empty-notice';
-import { onSearchEvent } from '../search-bar/search-bar';
 import '../template-card/template-card';
-import { store } from '../../redux/store';
-import { setSelectedTemplate } from '../../redux/actions';
-import { templatesManager } from '../../data/templates';
-import { connect } from 'pwa-helpers';
-import { AppCreatorStore } from '../../redux/reducer';
+import '@cwmr/paper-chip/paper-chip.js';
+import { chips } from '../../utils/helpers';
 
 export interface TemplatesTabItem {
   id: string;
   name: string;
   markup: TemplateResult;
+  device: DeviceType;
 }
 
 @customElement('templates-tab')
@@ -42,11 +47,30 @@ export class TemplatesTab extends connect(store)(LitElement) {
     #cards-container {
       margin-top: var(--regular);
     }
+
+    #chips-container {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      justify-content: center;
+      margin-top: var(--tight);
+    }
+
+    paper-chip {
+      margin: 0px var(--extra-tight);
+      background-color: var(--primary-color);
+      color: var(--accent-color);
+    }
+
+    .selected-paper-chip {
+      background-color: var(--accent-color);
+      color: var(--primary-color);
+    }
   `;
 
   stateChanged(state: AppCreatorStore) {
-    if (state.template.id !== this.selectedTemplateID) {
-      this.selectedTemplateID = state.template.id;
+    if (state.template.config.parentID !== this.selectedTemplateID) {
+      this.selectedTemplateID = state.template.config.parentID;
       this.requestUpdate();
     }
   }
@@ -61,12 +85,18 @@ export class TemplatesTab extends connect(store)(LitElement) {
    */
   @property({ type: String }) query = '';
 
+  /**
+   * Sets device filter.
+   */
+  @property({ type: String }) deviceFilter = DeviceType.all;
+
   getTemplateCards(showTitle = false) {
     const templates = templatesManager.getTemplates();
-    return templates.map(({ id, name, imageUrl, template }) => {
+    return templates.map(({ id, name, imageUrl, device, template }) => {
       return {
         id,
         name,
+        device,
         markup: html`
           ${showTitle ? nothing : html`<h6 class="subtitle">${name}</h6>`}
           <template-card
@@ -85,15 +115,22 @@ export class TemplatesTab extends connect(store)(LitElement) {
    * Returns widgets with names and ids that include the search query.
    */
   static filterTemplates(
-    templateCards: { id: string; name: string; markup: TemplateResult }[],
-    query: string
+    templateCards: TemplatesTabItem[],
+    query: string,
+    deviceFilter: DeviceType
   ): Array<TemplatesTabItem> {
-    return templateCards.filter(({ id, name }) => {
+    return templateCards.filter(({ id, name, device }) => {
       const lowerCasedQuery = query.toLowerCase();
-      return (
-        id.toLowerCase().includes(lowerCasedQuery) ||
-        name.toLowerCase().includes(lowerCasedQuery)
-      );
+      // Matches either the ID or name.
+      const queryMatch =
+        id.match(new RegExp(`.*${lowerCasedQuery}.*`, 'i')) ||
+        name.match(new RegExp(`.*${lowerCasedQuery}.*`, 'i'));
+
+      // And matches the device type (or all).
+      const deviceMatch =
+        deviceFilter === DeviceType.all || device === deviceFilter;
+
+      return queryMatch && deviceMatch;
     });
   }
 
@@ -112,14 +149,19 @@ export class TemplatesTab extends connect(store)(LitElement) {
     this.query = query.trim();
   }
 
+  handleDeviceFilters(device: DeviceType) {
+    this.deviceFilter = device;
+  }
+
   render() {
-    const { query, getTemplateCards, handleSearch } = this;
+    const { query, deviceFilter, getTemplateCards, handleSearch } = this;
 
     const templateCards = getTemplateCards.call(this);
 
     const filteredTemplates = TemplatesTab.filterTemplates(
       templateCards,
-      query
+      query,
+      deviceFilter
     );
 
     const emptyNotice = html`
@@ -132,12 +174,32 @@ export class TemplatesTab extends connect(store)(LitElement) {
       ></empty-notice>
     `;
 
+    const sortingChips = html`
+      <div id="chips-container">
+        ${chips.map(({ label, device }) => {
+          return html`
+            <paper-chip
+              selectable
+              class=${classMap({
+                'selected-paper-chip': this.deviceFilter === device,
+              })}
+              @click=${() => {
+                this.deviceFilter = device;
+              }}
+              >${label}</paper-chip
+            >
+          `;
+        })}
+      </div>
+    `;
+
     return html`
       <tab-container title="Templates">
         <search-bar
           placeholder="Search for template (ie. side panel)"
           @onsearch=${handleSearch}
         ></search-bar>
+        ${sortingChips}
         <div id="cards-container">
           ${filteredTemplates.map(({ markup }) => markup)}
           ${filteredTemplates.length === 0 ? emptyNotice : nothing}

--- a/app-creator/client/src/widgets/templates-tab/test/templates-tab_test.ts
+++ b/app-creator/client/src/widgets/templates-tab/test/templates-tab_test.ts
@@ -3,6 +3,8 @@
  */
 import { TemplatesTab } from '../templates-tab';
 import { fixture, html, expect, assert } from '@open-wc/testing';
+import { DeviceType } from '../../../redux/types/enums';
+import '../templates-tab/templates-tab';
 
 suite('templates-tab', () => {
   test('is defined', () => {
@@ -14,4 +16,56 @@ suite('templates-tab', () => {
     const el = await fixture(html`<templates-tab></templates-tab>`);
     expect(el.shadowRoot!.childNodes.length).to.be.greaterThan(0);
   });
+
+  suite('filter template cards', () => {
+    test('Empty query from all devices', () => {
+      const result = TemplatesTab.filterTemplates(
+        templatesStub,
+        '',
+        DeviceType.all
+      );
+      expect(result.length).to.equal(templatesStub.length);
+    });
+
+    test('Sub query from all devices', () => {
+      const result = TemplatesTab.filterTemplates(
+        templatesStub,
+        'le',
+        DeviceType.all
+      );
+      expect(result.length).to.equal(
+        templatesStub.filter(({ name }) => name.includes('Le')).length
+      );
+    });
+
+    test('Sub query from mobile devices', () => {
+      const result = TemplatesTab.filterTemplates(
+        templatesStub,
+        'le',
+        DeviceType.mobile
+      );
+      expect(result.length).to.equal(1);
+    });
+  });
 });
+
+const templatesStub = [
+  {
+    id: '0',
+    name: 'Left Side Panel',
+    markup: html``,
+    device: DeviceType.desktop,
+  },
+  {
+    id: '1',
+    name: 'Left Drawer Mobile',
+    markup: html``,
+    device: DeviceType.mobile,
+  },
+  {
+    id: '2',
+    name: 'Right Side Panel',
+    markup: html``,
+    device: DeviceType.desktop,
+  },
+];

--- a/app-creator/client/src/widgets/tool-bar/tool-bar.ts
+++ b/app-creator/client/src/widgets/tool-bar/tool-bar.ts
@@ -15,6 +15,7 @@ import '@polymer/paper-button/paper-button.js';
 import '@polymer/paper-dialog/paper-dialog.js';
 import '@polymer/paper-dialog-scrollable/paper-dialog-scrollable.js';
 import '@polymer/paper-toast/paper-toast.js';
+import { deepCloneTemplate } from '../../utils/helpers';
 
 @customElement('tool-bar')
 export class ToolBar extends LitElement {
@@ -105,6 +106,11 @@ export class ToolBar extends LitElement {
     #invalid-json-toast {
       background-color: var(--validation-error-red-color);
     }
+
+    #preview-dialog {
+      height: 100%;
+      width: 100%;
+    }
   `;
 
   /**
@@ -153,38 +159,10 @@ export class ToolBar extends LitElement {
   }
 
   /**
-   * Returns a deep clone of template without widgetRefs.
-   */
-  deepCloneTemplate(
-    template: AppCreatorStore['template']
-  ): AppCreatorStore['template'] {
-    const clone: AppCreatorStore['template'] = {};
-    for (const key in template) {
-      /**
-       * Widget refs are only needed in the context of the app creator. Once we serialize the data,
-       * we no longer need to keep the refs. As a result, we skip over them when we are producing the
-       * output string.
-       */
-      if (key === WIDGET_REF) {
-        continue;
-      }
-      if (typeof template[key] === 'object' && !Array.isArray(template[key])) {
-        clone[key] = this.deepCloneTemplate(template[key]);
-      } else if (Array.isArray(template[key])) {
-        clone[key] = template[key].slice();
-      } else {
-        clone[key] = template[key];
-      }
-    }
-
-    return clone;
-  }
-
-  /**
    * Returns the serialized template string with indentation.
    */
   getTemplateString(space: number = 0) {
-    const template = this.deepCloneTemplate(store.getState().template);
+    const template = deepCloneTemplate(store.getState().template);
     return JSON.stringify(template, null, space);
   }
 
@@ -324,6 +302,9 @@ export class ToolBar extends LitElement {
         </h3>
 
         <div>
+          <paper-button id="import-button" @click=${openImportDialog}
+            >Duplicate</paper-button
+          >
           <paper-button id="import-button" @click=${openImportDialog}
             >Import</paper-button
           >

--- a/app-creator/client/src/widgets/tool-bar/tool-bar.ts
+++ b/app-creator/client/src/widgets/tool-bar/tool-bar.ts
@@ -7,15 +7,18 @@
 import { LitElement, html, customElement, css, query } from 'lit-element';
 import { store } from '../../redux/store';
 import { PaperDialogElement } from '@polymer/paper-dialog/paper-dialog.js';
-import { AppCreatorStore } from '../../redux/reducer';
-import { WIDGET_REF, ROOT_ID } from '../../utils/constants';
+import { ROOT_ID } from '../../utils/constants';
 import { setSelectedTemplate } from '../../redux/actions';
 import { PaperToastElement } from '@polymer/paper-toast/paper-toast.js';
+import {
+  deepCloneTemplate,
+  storeTemplateInLocalStorage,
+} from '../../utils/helpers';
 import '@polymer/paper-button/paper-button.js';
 import '@polymer/paper-dialog/paper-dialog.js';
 import '@polymer/paper-dialog-scrollable/paper-dialog-scrollable.js';
 import '@polymer/paper-toast/paper-toast.js';
-import { deepCloneTemplate } from '../../utils/helpers';
+import { incrementWidgetIDs } from '../../utils/template-generation';
 
 @customElement('tool-bar')
 export class ToolBar extends LitElement {
@@ -212,6 +215,8 @@ export class ToolBar extends LitElement {
       // Update the store with the new template.
       store.dispatch(setSelectedTemplate(templateJSON));
 
+      incrementWidgetIDs(templateJSON.widgets);
+
       this.importDialog.close();
 
       this.clearTextArea('import-textarea');
@@ -239,12 +244,28 @@ export class ToolBar extends LitElement {
     textarea.value = '';
   }
 
+  /**
+   * Callback triggered when duplicate button is clicked.
+   */
+  handleDuplicateButtonAction() {
+    try {
+      storeTemplateInLocalStorage();
+
+      let url = location.href;
+
+      window.open(url);
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
   render() {
     const {
       openExportDialog,
       openImportDialog,
       importTemplate,
       clearTextArea,
+      handleDuplicateButtonAction,
       copy,
     } = this;
 
@@ -302,7 +323,7 @@ export class ToolBar extends LitElement {
         </h3>
 
         <div>
-          <paper-button id="import-button" @click=${openImportDialog}
+          <paper-button id="import-button" @click=${handleDuplicateButtonAction}
             >Duplicate</paper-button
           >
           <paper-button id="import-button" @click=${openImportDialog}

--- a/app-creator/client/src/widgets/tool-bar/tool-bar.ts
+++ b/app-creator/client/src/widgets/tool-bar/tool-bar.ts
@@ -4,17 +4,17 @@
  *  displaying a serialized template string that the user can copy
  *  and import into the code editor.
  */
-import '@polymer/paper-button/paper-button.js';
-import '@polymer/paper-dialog/paper-dialog.js';
-import '@polymer/paper-dialog-scrollable/paper-dialog-scrollable.js';
-import '@polymer/paper-toast/paper-toast.js';
 import { LitElement, html, customElement, css, query } from 'lit-element';
 import { store } from '../../redux/store';
 import { PaperDialogElement } from '@polymer/paper-dialog/paper-dialog.js';
 import { AppCreatorStore } from '../../redux/reducer';
 import { WIDGET_REF, ROOT_ID } from '../../utils/constants';
-import { setSelectedTemplate, setImporting } from '../../redux/actions';
+import { setSelectedTemplate } from '../../redux/actions';
 import { PaperToastElement } from '@polymer/paper-toast/paper-toast.js';
+import '@polymer/paper-button/paper-button.js';
+import '@polymer/paper-dialog/paper-dialog.js';
+import '@polymer/paper-dialog-scrollable/paper-dialog-scrollable.js';
+import '@polymer/paper-toast/paper-toast.js';
 
 @customElement('tool-bar')
 export class ToolBar extends LitElement {
@@ -233,7 +233,6 @@ export class ToolBar extends LitElement {
 
       // Update the store with the new template.
       store.dispatch(setSelectedTemplate(templateJSON));
-      store.dispatch(setImporting(true));
 
       this.importDialog.close();
 
@@ -249,6 +248,7 @@ export class ToolBar extends LitElement {
     }
   }
 
+  // Empties text area input.
   clearTextArea(id: string) {
     const textarea = this.shadowRoot?.querySelector(
       `#${id}`

--- a/app-creator/client/src/widgets/ui-panel/ui-panel.ts
+++ b/app-creator/client/src/widgets/ui-panel/ui-panel.ts
@@ -8,8 +8,8 @@ import { setEditingWidget } from '../../redux/actions';
 import { DraggableWidget } from '../draggable-widget/draggable-widget';
 import { Dropzone } from '../dropzone-widget/dropzone-widget';
 import { classMap } from 'lit-html/directives/class-map';
-import '../dropzone-widget/dropzone-widget';
 import { Layout } from '../../redux/types/enums';
+import '../dropzone-widget/dropzone-widget';
 
 @customElement('ui-panel')
 export class Panel extends LitElement {

--- a/app-creator/client/src/widgets/ui-panel/ui-panel.ts
+++ b/app-creator/client/src/widgets/ui-panel/ui-panel.ts
@@ -3,11 +3,13 @@
  *  are essentially containers that can align their children vertically, horizontally, and in a grid.
  */
 import { css, customElement, html, LitElement, property } from 'lit-element';
-import '../dropzone-widget/dropzone-widget';
 import { store } from '../../redux/store';
 import { setEditingWidget } from '../../redux/actions';
 import { DraggableWidget } from '../draggable-widget/draggable-widget';
-import { CONTAINER_ID } from '../dropzone-widget/dropzone-widget';
+import { Dropzone } from '../dropzone-widget/dropzone-widget';
+import { classMap } from 'lit-html/directives/class-map';
+import '../dropzone-widget/dropzone-widget';
+import { Layout } from '../../redux/types/enums';
 
 @customElement('ui-panel')
 export class Panel extends LitElement {
@@ -31,11 +33,11 @@ export class Panel extends LitElement {
       width: calc(100% - 2 * var(--extra-tight));
     }
 
-    .column {
+    .COLUMN {
       flex-direction: column;
     }
 
-    .row {
+    .ROW {
       flex-direction: row;
     }
 
@@ -74,7 +76,7 @@ export class Panel extends LitElement {
    * column layout will append widgets below the last child element.
    * row layout will append widgets to the right of the last child element.
    */
-  @property({ type: String }) layout = 'column';
+  @property({ type: String }) layout = Layout.COLUMN;
 
   /**
    * Adds a border and shadow to panel.
@@ -112,12 +114,19 @@ export class Panel extends LitElement {
     // Remove highlight from currently selected widget (if any).
     DraggableWidget.removeEditingWidgetHighlight();
 
-    const dropzone = this.querySelector(
-      'dropzone-widget'
-    )?.shadowRoot?.querySelector(`#${CONTAINER_ID}`);
+    let dropzone = this.querySelector('dropzone-widget') as Dropzone;
+
+    if (dropzone == null) {
+      dropzone = this.querySelector('slot')
+        ?.assignedNodes()
+        .find((node) => node.nodeName === 'DROPZONE-WIDGET') as Dropzone;
+    }
 
     if (dropzone != null) {
-      (dropzone as HTMLElement).style.borderColor = 'var(--accent-color)';
+      (dropzone as Dropzone).setStyleProperty(
+        'borderColor',
+        'var(--accent-color)'
+      );
     }
 
     // Check if a widgetRef has been set.
@@ -130,7 +139,7 @@ export class Panel extends LitElement {
     return html`
       <div
         id="container"
-        class="${layout} ${isRaised ? 'raised' : ''} ${padded ? 'padded' : ''}"
+        class=${classMap({ raised: isRaised, padded, [layout]: true })}
       >
         <slot class="${layout}"></slot>
       </div>
@@ -140,7 +149,7 @@ export class Panel extends LitElement {
   setAttribute(key: string, value: string) {
     switch (key) {
       case 'layout':
-        this.layout = value;
+        this.layout = value.toUpperCase() as Layout;
         return;
       case 'isRaised':
         this.isRaised = value === 'true';

--- a/app-creator/client/src/widgets/ui-sidemenu/ui-sidemenu.ts
+++ b/app-creator/client/src/widgets/ui-sidemenu/ui-sidemenu.ts
@@ -113,7 +113,6 @@ export class SideMenu extends LitElement {
 
   setStyle(style: { [key: string]: string }) {
     const filteredStyles = new Set(['position', 'top', 'left', 'width']);
-
     for (const attr in style) {
       if (!filteredStyles.has(attr)) {
         this.styles[attr] = style[attr];

--- a/app-creator/client/src/widgets/ui-sidemenu/ui-sidemenu.ts
+++ b/app-creator/client/src/widgets/ui-sidemenu/ui-sidemenu.ts
@@ -11,6 +11,7 @@ import {
   query,
 } from 'lit-element';
 import { Panel } from '../ui-panel/ui-panel';
+import { styleMap } from 'lit-html/directives/style-map';
 import { classMap } from 'lit-html/directives/class-map';
 import { Layout } from '../../redux/types/enums';
 import '@polymer/paper-icon-button/paper-icon-button.js';
@@ -77,7 +78,7 @@ export class SideMenu extends LitElement {
   /**
    * Additional custom styles
    */
-  @property({ type: Object }) styles = {};
+  @property({ type: Object }) styles: { [key: string]: string } = {};
 
   /**
    * Sets editable property.
@@ -112,13 +113,13 @@ export class SideMenu extends LitElement {
 
   setStyle(style: { [key: string]: string }) {
     const filteredStyles = new Set(['position', 'top', 'left', 'width']);
-    if (this.panel != null) {
-      for (const attribute in style) {
-        if (!filteredStyles.has(attribute)) {
-          this.panel.style[attribute as any] = style[attribute];
-        }
+
+    for (const attr in style) {
+      if (!filteredStyles.has(attr)) {
+        this.styles[attr] = style[attr];
       }
     }
+
     this.requestUpdate();
   }
 
@@ -136,10 +137,10 @@ export class SideMenu extends LitElement {
   }
 
   render() {
-    const { toggleMenu, layout } = this;
+    const { toggleMenu, layout, styles } = this;
     return html`
       <div id="container">
-        <ui-panel>
+        <ui-panel style=${styleMap(styles)}>
           <slot class=${classMap({ [layout]: true })}></slot>
         </ui-panel>
         <paper-icon-button

--- a/app-creator/client/src/widgets/ui-sidemenu/ui-sidemenu.ts
+++ b/app-creator/client/src/widgets/ui-sidemenu/ui-sidemenu.ts
@@ -10,8 +10,9 @@ import {
   property,
   query,
 } from 'lit-element';
-import { styleMap } from 'lit-html/directives/style-map';
 import { Panel } from '../ui-panel/ui-panel';
+import { classMap } from 'lit-html/directives/class-map';
+import { Layout } from '../../redux/types/enums';
 import '@polymer/paper-icon-button/paper-icon-button.js';
 import '@polymer/iron-icons/iron-icons.js';
 import '../ui-panel/ui-panel';
@@ -25,6 +26,8 @@ export class SideMenu extends LitElement {
     paper-icon-button {
       margin: var(--tight);
       pointer-events: auto;
+      background-color: white;
+      border-radius: 50%;
     }
 
     #container {
@@ -49,11 +52,11 @@ export class SideMenu extends LitElement {
       height: 100%;
     }
 
-    .column {
+    .COLUMN {
       flex-direction: column;
     }
 
-    .row {
+    .ROW {
       flex-direction: row;
     }
   `;
@@ -64,7 +67,7 @@ export class SideMenu extends LitElement {
    * column layout will append widgets below the last child element.
    * row layout will append widgets to the right of the last child element.
    */
-  @property({ type: String }) layout = 'column';
+  @property({ type: String }) layout = Layout.COLUMN;
 
   /**
    * Contains an inner dropzone-widget.
@@ -87,14 +90,16 @@ export class SideMenu extends LitElement {
   @query('ui-panel') panel!: Panel;
 
   firstUpdated() {
-    if (this.panel != null) {
+    if (this.panel) {
       this.panel.id = this.id;
     }
   }
 
-  toggleMenu() {
+  toggleMenu(e: Event) {
+    e.stopPropagation();
+
     const { panel } = this;
-    if (panel == null) {
+    if (!panel) {
       return;
     }
 
@@ -106,9 +111,12 @@ export class SideMenu extends LitElement {
   }
 
   setStyle(style: { [key: string]: string }) {
+    const filteredStyles = new Set(['position', 'top', 'left', 'width']);
     if (this.panel != null) {
       for (const attribute in style) {
-        this.panel.style[attribute as any] = style[attribute];
+        if (!filteredStyles.has(attribute)) {
+          this.panel.style[attribute as any] = style[attribute];
+        }
       }
     }
     this.requestUpdate();
@@ -117,22 +125,22 @@ export class SideMenu extends LitElement {
   setAttribute(key: string, value: string) {
     switch (key) {
       case 'layout':
-        this.layout = value;
-        return;
+        this.layout = value.toUpperCase() as Layout;
+        break;
       case 'hasDropzone':
         this.hasDropzone = value === 'true';
-        return;
+        break;
     }
 
     this.requestUpdate();
   }
 
   render() {
-    const { styles, toggleMenu, layout } = this;
+    const { toggleMenu, layout } = this;
     return html`
-      <div id="container" style=${styleMap(styles)}>
+      <div id="container">
         <ui-panel>
-          <slot class="${layout}"></slot>
+          <slot class=${classMap({ [layout]: true })}></slot>
         </ui-panel>
         <paper-icon-button
           icon="icons:menu"

--- a/app-creator/client/style.css
+++ b/app-creator/client/style.css
@@ -24,7 +24,7 @@ p {
   --accent-color: #202124;
   --app-title-suffix-color: #5f6368;
   --background-color: #f5f6f9;
-  --border-gray: rgba(0, 0, 0, 0.3);
+  --border-gray: #636e72;
   --light-border: 0.6px solid var(--border-gray);
   --light-dashed-border: 0.8px dashed var(--border-gray);
   --paper-checkbox-checked-color: var(--accent-color);


### PR DESCRIPTION
## What are we adding in this PR

This PR adds template duplication and widget sharing. It allows users to change templates without having to lose their data. It also allows them to create duplicates so they can build multiple variations of a particular template (i.e. Light/Dark, English/French/Spanish). This provides a flexible interface for creating multiple themes with multiple translations. 

Here are some examples: 

**Light/English**
![Screenshot 2020-08-02 at 9 47 11 PM](https://user-images.githubusercontent.com/26859947/89212898-4a7f0000-d592-11ea-904b-8b5d244dc050.png)

**Light/Arabic**
![Screenshot 2020-08-02 at 9 46 22 PM](https://user-images.githubusercontent.com/26859947/89212915-51a60e00-d592-11ea-9950-3d5d576754d4.png)

**Dark/English**
![Screenshot 2020-08-02 at 9 46 46 PM](https://user-images.githubusercontent.com/26859947/89212940-5b2f7600-d592-11ea-8757-8d4969bf3edc.png)

**Dark/Arabic**
![Screenshot 2020-08-02 at 9 45 59 PM](https://user-images.githubusercontent.com/26859947/89212955-5ff42a00-d592-11ea-94f3-5ff16fcb1312.png)
