### PR TITLE
Added duplication and widget sharing

### DIFF
--- a/app-creator/client/src/client/fetch-templates.ts
+++ b/app-creator/client/src/client/fetch-templates.ts
@@ -50,7 +50,7 @@ export const database: TemplateItem[] = [
                 "id": "panel-template-1",
                 "editable": true,
                 "hasDropzone": true,
-                "children": ["label-template-0", "label-template-1", "button-template-0"],
+                "children": [],
                 "uniqueAttributes": {
                     "layout": "column"
                 },
@@ -83,38 +83,6 @@ export const database: TemplateItem[] = [
                     "margin": "0px",
                     "boxSizing": "border-box"
                 }
-            },
-            "label-template-0": {
-                "id": "label-template-0",
-                "children": [],
-                "uniqueAttributes": {
-                    "value": "Earth Engine",
-                    "targetUrl": ""
-                },
-                "style": {
-                    "fontSize": "32px",
-                    "fontWeight": "700"
-                }
-            },
-            "label-template-1": {
-                "id": "label-template-1",
-                "children": [],
-                "uniqueAttributes": {
-                    "value": "Google Earth Engine combines a multi-petabyte catalog of satellite imagery and geospatial datasets with planetary-scale analysis capabilities and makes it available for scientists, researchers, and developers to detect changes, map trends, and quantify differences on the Earth\'s surface.",
-                    "targetUrl": ""
-                },
-                "style": {
-                    "fontSize": "14px"
-                }
-            },
-            "button-template-0": {
-                "id": "button-template-0",
-                "children": [],
-                "uniqueAttributes": {
-                    "label": "Button",
-                    "disabled": "false"
-                },
-                "style": {}
             }
         }
     }`,
@@ -155,11 +123,7 @@ export const database: TemplateItem[] = [
                 "id": "sidemenu-template-0",
                 "editable": true,
                 "hasDropzone": true,
-                "children": [
-                    "label-template-0",
-                    "label-template-1",
-                    "button-template-0"
-                ],
+                "children": [],
                 "uniqueAttributes": {
                     "layout": "column"
                 },
@@ -176,38 +140,6 @@ export const database: TemplateItem[] = [
                     "zIndex": 10
                 }
             },
-            "label-template-0": {
-                "id": "label-template-0",
-                "children": [],
-                "uniqueAttributes": {
-                   "value": "Earth Engine",
-                   "targetUrl": ""
-                },
-                "style": {
-                   "fontSize": "32px",
-                   "fontWeight": "700"
-                }
-             },
-             "label-template-1": {
-                "id": "label-template-1",
-                "children": [],
-                "uniqueAttributes": {
-                   "value": "Google Earth Engine combines a multi-petabyte catalog of satellite imagery and geospatial datasets with planetary-scale analysis capabilities and makes it available for scientists, researchers, and developers to detect changes, map trends, and quantify differences on the Earth's surface.",
-                   "targetUrl": ""
-                },
-                "style": {
-                   "backgroundColor": "#FFFFFF00"
-                }
-             },
-             "button-template-0": {
-                "id": "button-template-0",
-                "children": [],
-                "uniqueAttributes": {
-                   "label": "Button",
-                   "disabled": "false"
-                },
-                "style": {}
-             },
             "map-template-0": {
                 "id": "map-template-0",
                 "children": [],
@@ -268,7 +200,7 @@ export const database: TemplateItem[] = [
                 "id": "panel-template-1",
                 "editable": true,
                 "hasDropzone": true,
-                "children": ["label-template-0", "label-template-1", "button-template-0"],
+                "children": [],
                 "uniqueAttributes": {
                     "layout": "column"
                 },
@@ -301,44 +233,6 @@ export const database: TemplateItem[] = [
                     "backgroundColor": "#FFFFFFFF",
                     "backgroundOpacity": "100",
                     "boxSizing": "border-box"
-                }
-            },
-            "label-template-0": {
-                "id": "label-template-0",
-                "children": [],
-                "uniqueAttributes": {
-                    "value": "Earth Engine",
-                    "targetUrl": ""
-                },
-                "style": {
-                    "margin": "8px",
-                    "backgroundColor": "#FFFFFF00",
-                    "fontSize": "32px",
-                    "fontWeight": "700"
-                }
-            },
-            "label-template-1": {
-                "id": "label-template-1",
-                "children": [],
-                "uniqueAttributes": {
-                    "value": "Google Earth Engine combines a multi-petabyte catalog of satellite imagery and geospatial datasets with planetary-scale analysis capabilities and makes it available for scientists, researchers, and developers to detect changes, map trends, and quantify differences on the Earth\'s surface.",
-                    "targetUrl": ""
-                },
-                "style": {
-                    "margin": "8px",
-                    "backgroundColor": "#FFFFFF00",
-                    "fontSize": "14px"
-                }
-            },
-            "button-template-0": {
-                "id": "button-template-0",
-                "children": [],
-                "uniqueAttributes": {
-                    "label": "Button",
-                    "disabled": "false"
-                },
-                "style": {
-                    "margin": "8px"
                 }
             }
         }
@@ -379,7 +273,7 @@ export const database: TemplateItem[] = [
                 "id": "panel-template-1",
                 "editable": true,
                 "hasDropzone": true,
-                "children": ["label-template-1", "label-template-0", "button-template-0"],
+                "children": [],
                 "uniqueAttributes": {
                     "layout": "column"
                 },
@@ -417,42 +311,6 @@ export const database: TemplateItem[] = [
                     "width": "100%",
                     "margin": "0px",
                     "boxSizing": "border-box"
-                }
-            },
-            "label-template-0": {
-                "id": "label-template-0",
-                "children": [],
-                "uniqueAttributes": {
-                    "value": "Google Earth Engine combines a multi-petabyte catalog of satellite imagery and geospatial datasets with planetary-scale analysis capabilities and makes it available for scientists, researchers, and developers to detect changes, map trends, and quantify differences on the surface of the earth.",
-                    "targetUrl": ""
-                },
-                "style": {
-                    "margin": "8px",
-                    "fontSize": "16px"
-                }
-            },
-            "button-template-0": {
-                "id": "button-template-0",
-                "children": [],
-                "uniqueAttributes": {
-                    "label": "Button",
-                    "disabled": "false"
-                },
-                "style": {
-                    "margin": "8px"
-                }
-            },
-            "label-template-1": {
-                "id": "label-template-1",
-                "children": [],
-                "uniqueAttributes": {
-                    "value": "Earth Engine",
-                    "targetUrl": ""
-                },
-                "style": {
-                    "margin": "8px",
-                    "fontSize": "32px",
-                    "fontWeight": "700"
                 }
             }
         }
@@ -493,7 +351,7 @@ export const database: TemplateItem[] = [
                 "id": "panel-template-1",
                 "editable": true,
                 "hasDropzone": true,
-                "children": ["label-template-3", "label-template-2", "button-template-0"],
+                "children": [],
                 "uniqueAttributes": {
                     "layout": "column"
                 },
@@ -516,7 +374,7 @@ export const database: TemplateItem[] = [
                 "id": "panel-template-2",
                 "editable": true,
                 "hasDropzone": true,
-                "children": ["label-template-4", "label-template-0", "button-template-1"],
+                "children": [],
                 "uniqueAttributes": {
                     "layout": "column"
                 },
@@ -580,359 +438,6 @@ export const database: TemplateItem[] = [
                     "backgroundColor": "#FFFFFFFF",
                     "backgroundOpacity": "100",
                     "boxSizing": "border-box"
-                }
-            },
-            "label-template-0": {
-                "id": "label-template-0",
-                "children": [],
-                "uniqueAttributes": {
-                    "value": "Google Earth Engine combines a multi-petabyte catalog of satellite imagery and geospatial datasets with planetary-scale analysis capabilities and makes it available for scientists, researchers, and developers to detect changes, map trends, and quantify differences on the Earth\'s surface.",
-                    "targetUrl": ""
-                },
-                "style": {
-                    "margin": "8px",
-                    "backgroundColor": "#FFFFFF00",
-                    "fontSize": "14px"
-                }
-            },
-            "label-template-2": {
-                "id": "label-template-2",
-                "children": [],
-                "uniqueAttributes": {
-                    "value": "Google Earth Engine combines a multi-petabyte catalog of satellite imagery and geospatial datasets with planetary-scale analysis capabilities and makes it available for scientists, researchers, and developers to detect changes, map trends, and quantify differences on the Earth\'s surface.",
-                    "targetUrl": ""
-                },
-                "style": {
-                    "margin": "8px",
-                    "color": "#ffffff",
-                    "backgroundColor": "#FFFFFF00",
-                    "fontSize": "14px"
-                }
-            },
-            "button-template-0": {
-                "id": "button-template-0",
-                "children": [],
-                "uniqueAttributes": {
-                    "label": "Button",
-                    "disabled": "false"
-                },
-                "style": {
-                    "margin": "8px"
-                }
-            },
-            "button-template-1": {
-                "id": "button-template-1",
-                "children": [],
-                "uniqueAttributes": {
-                    "label": "Button",
-                    "disabled": "false"
-                },
-                "style": {
-                    "margin": "8px"
-                }
-            },
-            "label-template-3": {
-                "id": "label-template-3",
-                "children": [],
-                "uniqueAttributes": {
-                    "value": "Earth Engine",
-                    "targetUrl": ""
-                },
-                "style": {
-                    "margin": "8px",
-                    "fontSize": "22px",
-                    "fontWeight": "700"
-                }
-            },
-            "label-template-4": {
-                "id": "label-template-4",
-                "children": [],
-                "uniqueAttributes": {
-                    "value": "Earth Engine",
-                    "targetUrl": ""
-                },
-                "style": {
-                    "margin": "8px",
-                    "fontSize": "22px",
-                    "fontWeight": "700"
-                }
-            }
-        }
-           
-    }`,
-  },
-  {
-    id: 'four-maps',
-    name: 'Four Maps',
-    imageUrl:
-      'https://storage.cloud.google.com/ee-app-creator.appspot.com/four-maps.png',
-    device: DeviceType.DESKTOP,
-    template: `{
-        "config": {
-            "parentID": "four-maps",
-            "parentName": "Four Maps",
-            "id": "four-maps-desktop",
-            "name": "Four Maps Desktop",
-            "device": "desktop"
-        },
-        "widgets": {
-            "panel-template-0": {
-                "id": "panel-template-0",
-                "editable": false,
-                "hasDropzone": false,
-                "children": ["panel-template-1", "panel-template-2"],
-                "uniqueAttributes": {
-                    "layout": "column"
-                },
-                "style": {
-                    "height": "100%",
-                    "width": "100%",
-                    "margin": "0px",
-                    "position": "relative",
-                    "boxSizing": "border-box"
-                }
-            },
-            "panel-template-1": {
-                "id": "panel-template-1",
-                "editable": true,
-                "hasDropzone": true,
-                "children": ["label-template-0"],
-                "uniqueAttributes": {
-                    "layout": "column"
-                },
-                "style": {
-                    "height": "8%",
-                    "width": "100%",
-                    "margin": "0px",
-                    "position": "relative",
-                    "boxSizing": "border-box"
-                }
-            },
-            "panel-template-2": {
-                "id": "panel-template-2",
-                "editable": false,
-                "hasDropzone": false,
-                "children": ["panel-template-3", "panel-template-4"],
-                "uniqueAttributes": {
-                    "layout": "column"
-                },
-                "style": {
-                    "height": "92%",
-                    "width": "100%",
-                    "margin": "0px",
-                    "boxSizing": "border-box"
-                }
-            },
-            "panel-template-3": {
-                "id": "panel-template-3",
-                "editable": false,
-                "hasDropzone": false,
-                "children": ["map-template-0", "map-template-1"],
-                "uniqueAttributes": {
-                    "layout": "row"
-                },
-                "style": {
-                    "height": "50%",
-                    "width": "100%",
-                    "margin": "0px",
-                    "boxSizing": "border-box"
-                }
-            },
-            "map-template-0": {
-                "id": "map-template-0",
-                "children": ["panel-template-5"],
-                "uniqueAttributes": {
-                    "zoom": "10",
-                    "latitude": "37.419857",
-                    "longitude": "-122.078827",
-                    "zoomControl": "false",
-                    "fullscreenControl": "false",
-                    "scaleControl": "false",
-                    "streetViewControl": "false",
-                    "mapTypeControl": "false",
-                    "mapStyles": "standard",
-                    "customMapStyles": ""
-                }, "style": {
-                    "height": "100%",
-                    "width": "50%",
-                    "margin": "0px",
-                    "boxSizing": "border-box"
-                }
-            },
-            "map-template-1": {
-                "id": "map-template-1",
-                "children": ["panel-template-6"],
-                "uniqueAttributes": {
-                    "zoom": "10",
-                    "latitude": "37.419857",
-                    "longitude": "-122.078827",
-                    "zoomControl": "false",
-                    "fullscreenControl": "false",
-                    "scaleControl": "false",
-                    "streetViewControl": "false",
-                    "mapTypeControl": "false",
-                    "mapStyles": "retro",
-                    "customMapStyles": ""
-                }, "style": {
-                    "height": "100%",
-                    "width": "50%",
-                    "margin": "0px",
-                    "boxSizing": "border-box"
-                }
-            },
-            "panel-template-4": {
-                "id": "panel-template-4",
-                "editable": false,
-                "hasDropzone": false,
-                "children": ["map-template-2", "map-template-3"],
-                "uniqueAttributes": {
-                    "layout": "row"
-                },
-                "style": {
-                    "height": "50%",
-                    "width": "100%",
-                    "margin": "0px",
-                    "boxSizing": "border-box"
-                }
-            },
-            "map-template-2": {
-                "id": "map-template-2",
-                "children": ["panel-template-7"],
-                "uniqueAttributes": {
-                    "zoom": "10",
-                    "latitude": "37.419857",
-                    "longitude": "-122.078827",
-                    "zoomControl": "false",
-                    "fullscreenControl": "false",
-                    "scaleControl": "false",
-                    "streetViewControl": "false",
-                    "mapTypeControl": "false",
-                    "mapStyles": "aubergine",
-                    "customMapStyles": ""
-                }, "style": {
-                    "height": "100%",
-                    "width": "50%",
-                    "margin": "0px",
-                    "boxSizing": "border-box"
-                }
-            },
-            "map-template-3": {
-                "id": "map-template-3",
-                "children": ["panel-template-8"],
-                "uniqueAttributes": {
-                    "zoom": "10",
-                    "latitude": "37.419857",
-                    "longitude": "-122.078827",
-                    "zoomControl": "false",
-                    "fullscreenControl": "false",
-                    "scaleControl": "false",
-                    "streetViewControl": "false",
-                    "mapTypeControl": "false",
-                    "mapStyles": "dark",
-                    "customMapStyles": ""
-                }, "style": {
-                    "height": "100%",
-                    "width": "50%",
-                    "margin": "0px",
-                    "boxSizing": "border-box"
-                }
-            },
-            "panel-template-5": {
-                "id": "panel-template-5",
-                "editable": true,
-                "hasDropzone": true,
-                "children": [],
-                "uniqueAttributes": {
-                    "layout": "column"
-                },
-                "style": {
-                    "height": "150px",
-                    "width": "300px",
-                    "margin": "0px",
-                    "position": "absolute",
-                    "top": "16px",
-                    "left": "16px",
-                    "boxSizing": "border-box",
-                    "zIndex": "1"
-                }
-            },
-            "panel-template-6": {
-                "id": "panel-template-6",
-                "editable": true,
-                "hasDropzone": true,
-                "children": [],
-                "uniqueAttributes": {
-                    "layout": "column"
-                },
-                "style": {
-                    "height": "150px",
-                    "width": "300px",
-                    "margin": "0px",
-                    "position": "absolute",
-                    "top": "16px",
-                    "right": "16px",
-                    "boxSizing": "border-box",
-                    "zIndex": "1"
-                }
-            },
-            "panel-template-7": {
-                "id": "panel-template-7",
-                "editable": true,
-                "hasDropzone": true,
-                "children": [],
-                "uniqueAttributes": {
-                    "layout": "column"
-                },
-                "style": {
-                    "height": "150px",
-                    "width": "300px",
-                    "margin": "0px",
-                    "position": "absolute",
-                    "bottom": "16px",
-                    "left": "16px",
-                    "boxSizing": "border-box",
-                    "zIndex": "1"
-                }
-            },
-            "panel-template-8": {
-                "id": "panel-template-8",
-                "editable": true,
-                "hasDropzone": true,
-                "children": [],
-                "uniqueAttributes": {
-                    "layout": "column"
-                },
-                "style": {
-                    "height": "150px",
-                    "width": "300px",
-                    "margin": "0px",
-                    "position": "absolute",
-                    "bottom": "16px",
-                    "right": "16px",
-                    "boxSizing": "border-box",
-                    "zIndex": "1"
-                }
-            },
-            "label-template-0": {
-                "id": "label-template-0",
-                "children": [],
-                "uniqueAttributes": {
-                   "value": "Earth Engine",
-                   "targetUrl": ""
-                },
-                "style": {
-                   "height": "px",
-                   "width": "98%",
-                   "margin": "8px",
-                   "borderWidth": "0px",
-                   "borderStyle": "solid",
-                   "borderColor": "black",
-                   "fontSize": "24px",
-                   "fontWeight": "700",
-                   "fontFamily": "Roboto",
-                   "textAlign": "center",
-                   "whiteSpace": "normal",
-                   "shown": "true"
                 }
             }
         }

--- a/app-creator/client/src/redux/actions.ts
+++ b/app-creator/client/src/redux/actions.ts
@@ -32,6 +32,8 @@ import {
   SET_PALETTE,
   SetEventType,
   SET_EVENT_TYPE,
+  UpdateWidgetIDs,
+  UPDATE_WIDGET_IDS,
 } from './types/actions';
 import {
   DEFAULT_SHARED_ATTRIBUTES,
@@ -124,7 +126,9 @@ export const setPalette = (palette: PaletteNames): SetPalette => {
  */
 export const addWidgetMetaData = (
   id: string,
-  widget: Element
+  widget: Element,
+  uniqueAttributes?: UniqueAttributes,
+  style?: { [key: string]: string }
 ): AddWidgetMetaData => {
   return {
     type: ADD_WIDGET_META_DATA,
@@ -133,11 +137,25 @@ export const addWidgetMetaData = (
         id,
         widgetRef: widget as HTMLElement,
         children: [],
-        uniqueAttributes: {
+        uniqueAttributes: uniqueAttributes ?? {
           ...getUniqueAttributes(getWidgetType(id)),
         },
-        style: { ...DEFAULT_SHARED_ATTRIBUTES },
+        style: style ?? { ...DEFAULT_SHARED_ATTRIBUTES },
       },
+    },
+  };
+};
+
+/**
+ * Updates widget IDs with new values. This is used after a template change to prevent id conflicts.
+ */
+export const updateWidgetIDs = (
+  updatedIDs: AppCreatorStore['widgetIDs']
+): UpdateWidgetIDs => {
+  return {
+    type: UPDATE_WIDGET_IDS,
+    payload: {
+      updatedIDs,
     },
   };
 };

--- a/app-creator/client/src/redux/helpers.ts
+++ b/app-creator/client/src/redux/helpers.ts
@@ -48,6 +48,7 @@ export function applyPalette(
     if (widgetId.startsWith('panel') || widgetId.startsWith('sidemenu')) {
       widgets[widgetId].style.backgroundColor =
         PalettePicker.palette[color].backgroundColor;
+      widgets[widgetId].style.color = PalettePicker.palette[color].color;
       widgets[widgetId].style.backgroundOpacity = '100';
     } else if (widgetId.startsWith('map')) {
       // Apply map styling.

--- a/app-creator/client/src/redux/helpers.ts
+++ b/app-creator/client/src/redux/helpers.ts
@@ -2,10 +2,11 @@
  * @fileoverview This file contains helper functions that are specific to the reducer itself.
  */
 import { AppCreatorStore, WidgetMetaData } from './reducer';
-import { PaletteNames } from './types/enums';
+import { PaletteNames, WidgetType } from './types/enums';
 import { PalettePicker } from '../widgets/palette-picker/palette-picker';
 import { EEWidget } from './types/types';
 import { UpdateWidgetMetaData } from './types/actions';
+import { ROOT_ID } from '../utils/constants';
 
 /**
  * Removes widget meta data from the current template.
@@ -45,24 +46,29 @@ export function applyPalette(
 ) {
   for (const widgetId in widgets) {
     // Set the background color of panel elements. Non-panel elements start with a transparent background.
-    if (widgetId.startsWith('panel') || widgetId.startsWith('sidemenu')) {
+    if (
+      widgetId.startsWith(WidgetType.PANEL) ||
+      widgetId.startsWith(WidgetType.SIDEMENU)
+    ) {
       widgets[widgetId].style.backgroundColor =
         PalettePicker.palette[color].backgroundColor;
-      widgets[widgetId].style.color = PalettePicker.palette[color].color;
+      if (widgetId === ROOT_ID) {
+        widgets[widgetId].style.color = PalettePicker.palette[color].color;
+      }
       widgets[widgetId].style.backgroundOpacity = '100';
-    } else if (widgetId.startsWith('map')) {
+    } else if (widgetId.startsWith(WidgetType.MAP)) {
       // Apply map styling.
       widgets[widgetId].uniqueAttributes.mapStyles =
         PalettePicker.palette[color].map;
     } else if (
-      !widgetId.startsWith('panel') &&
-      !widgetId.startsWith('button')
+      !widgetId.startsWith(WidgetType.PANEL) &&
+      !widgetId.startsWith(WidgetType.BUTTON)
     ) {
       // Apply color property on non-panel elements.
       widgets[widgetId].style.color = PalettePicker.palette[color].color;
       // Setting transparent background.
       widgets[widgetId].style.backgroundColor = '#ffffff00';
-    } else if (widgetId.startsWith('button')) {
+    } else if (widgetId.startsWith(WidgetType.BUTTON)) {
       // Apply styles for button elements.
       widgets[widgetId].style.backgroundColor =
         PalettePicker.palette[color].color;

--- a/app-creator/client/src/redux/reducer.ts
+++ b/app-creator/client/src/redux/reducer.ts
@@ -20,6 +20,7 @@ import {
   SET_PALETTE,
   SET_EVENT_TYPE,
   RemoveWidget,
+  UPDATE_WIDGET_IDS,
 } from './types/actions';
 import { Reducer, AnyAction } from 'redux';
 import { UniqueAttributes } from './types/attributes';
@@ -224,6 +225,14 @@ export const reducer: Reducer<AppCreatorStore, AppCreatorAction | AnyAction> = (
         widgetIDs: {
           ...state.widgetIDs,
           [action.payload.id]: state.widgetIDs[action.payload.id] + 1,
+        },
+      };
+    case UPDATE_WIDGET_IDS:
+      return {
+        ...state,
+        widgetIDs: {
+          ...state.widgetIDs,
+          ...action.payload.updatedIDs,
         },
       };
     case SET_SELECTED_TEMPLATE:

--- a/app-creator/client/src/redux/test/helpers_test.ts
+++ b/app-creator/client/src/redux/test/helpers_test.ts
@@ -11,9 +11,9 @@ import {
   applyPalette,
   updateWidgetAttribute,
 } from '../helpers';
-import { AppCreatorStore } from '../reducer';
 import { PaletteNames, AttributeType } from '../types/enums';
 import { PalettePicker } from '../../widgets/palette-picker/palette-picker';
+import { createTemplateStub } from '../../utils/test/helpers_test';
 
 suite('redux store helpers', () => {
   suite('palette changes', () => {
@@ -196,46 +196,3 @@ suite('redux store helpers', () => {
     });
   });
 });
-
-function createTemplateStub(): AppCreatorStore['template'] {
-  return {
-    widgets: {
-      'panel-0': {
-        children: ['label-0'],
-        style: {
-          backgroundColor: '#000000',
-          color: '#ffffff',
-        },
-      },
-      'label-0': {
-        id: 'label-0',
-        children: [],
-        uniqueAttributes: {},
-        style: {
-          backgroundColor: '#000000',
-          color: '#ffffff',
-        },
-      },
-      'button-0': {
-        id: 'button-0',
-        children: [],
-        uniqueAttributes: {},
-        style: {
-          backgroundColor: '#000000',
-          color: '#ffffff',
-        },
-      },
-      'map-0': {
-        id: 'map-0',
-        children: [],
-        uniqueAttributes: {
-          mapStyles: PaletteNames.AUBERGINE,
-        },
-        style: {
-          backgroundColor: '#ffffff',
-          color: '#ffffff',
-        },
-      },
-    },
-  };
-}

--- a/app-creator/client/src/redux/types/actions.ts
+++ b/app-creator/client/src/redux/types/actions.ts
@@ -19,6 +19,7 @@ export const UPDATE_WIDGET_CHILDREN = 'UPDATE_WIDGET_CHILDREN';
 export const SET_SELECTED_TEMPLATE_ID = 'SET_SELECTED_TEMPLATE_ID';
 export const SET_PALETTE = 'SET_PALETTE';
 export const SET_EVENT_TYPE = 'SET_EVENT_TYPE';
+export const UPDATE_WIDGET_IDS = 'UPDATE_WIDGET_IDS';
 
 export interface UpdateWidgetChildren {
   type: typeof UPDATE_WIDGET_CHILDREN;
@@ -75,6 +76,13 @@ export interface AddWidgetMetaData {
       uniqueAttributes: {};
       style: {};
     };
+  };
+}
+
+export interface UpdateWidgetIDs {
+  type: typeof UPDATE_WIDGET_IDS;
+  payload: {
+    updatedIDs: AppCreatorStore['widgetIDs'];
   };
 }
 
@@ -147,12 +155,13 @@ export type AppCreatorAction =
   | SetSelectedTabAction
   | SetIsReorderingAction
   | SetSelectedTemplate
-  | IncrementWidgetAction
-  | ResetDraggingValuesAction
-  | AddWidgetMetaData
-  | RemoveWidget
-  | UpdateWidgetMetaData
-  | UpdateWidgetChildren
   | SetSelectedTemplateIDAction
   | SetPalette
-  | SetEventType;
+  | SetEventType
+  | AddWidgetMetaData
+  | ResetDraggingValuesAction
+  | RemoveWidget
+  | IncrementWidgetAction
+  | UpdateWidgetMetaData
+  | UpdateWidgetChildren
+  | UpdateWidgetIDs;

--- a/app-creator/client/src/redux/types/enums.ts
+++ b/app-creator/client/src/redux/types/enums.ts
@@ -35,6 +35,7 @@ export enum EventType {
   REORDERING = 'reordering',
   ADDING = 'adding',
   CHANGINGPALETTE = 'changingPalette',
+  CHANGINGTEMPLATE = 'changingTemplate',
   NONE = 'none',
 }
 

--- a/app-creator/client/src/utils/constants.ts
+++ b/app-creator/client/src/utils/constants.ts
@@ -9,6 +9,16 @@ export const ROOT_ID = 'panel-template-0';
 export const WIDGET_REF = 'widgetRef';
 
 /**
+ * Key for template param.
+ */
+export const TEMPLATE_TIMESTAMP = 't';
+
+/**
+ * Local storage key for storing template snapshots.
+ */
+export const TEMPLATE_SNAPSHOTS = 'template_snapshots';
+
+/**
  * List of default map styles.
  */
 export const MAP_STYLES = [

--- a/app-creator/client/src/utils/helpers.ts
+++ b/app-creator/client/src/utils/helpers.ts
@@ -1,6 +1,9 @@
 import { DeviceType } from '../redux/types/enums';
 import { AppCreatorStore } from '../redux/reducer';
 import { WIDGET_REF } from './constants';
+import { store } from '../redux/store';
+import { html, TemplateResult } from 'lit-element';
+import '@polymer/paper-toast/paper-toast';
 
 /**
  * Converts camel case to title case.
@@ -61,6 +64,17 @@ export const chips = [
   },
 ];
 
+export function createToastMessage(
+  id: string,
+  message: string
+): TemplateResult {
+  return html`<paper-toast
+    id=${id}
+    text=${message}
+    duration="10000"
+  ></paper-toast> `;
+}
+
 /*
  * Generates random ids with length 32.
  */
@@ -98,4 +112,18 @@ export function deepCloneTemplate(
   }
 
   return clone;
+}
+
+/**
+ * Takes a snapshot of the current template and stores it in localStorage.
+ */
+export function storeTemplateInLocalStorage() {
+  /**
+   * Saving current template string in localStorage so we can transfer data across.
+   * */
+  const currentTemplate = JSON.stringify(
+    deepCloneTemplate(store.getState().template)
+  );
+
+  localStorage.setItem('previousTemplate', currentTemplate);
 }

--- a/app-creator/client/src/utils/template-generation.ts
+++ b/app-creator/client/src/utils/template-generation.ts
@@ -5,12 +5,18 @@
 import { AppCreatorStore, WidgetMetaData } from '../redux/reducer';
 import { ROOT_ID } from './constants';
 import { store } from '../redux/store';
-import { setSelectedTemplate } from '../redux/actions';
+import {
+  setSelectedTemplate,
+  addWidgetMetaData,
+  updateWidgetChildren,
+  setEventType,
+  updateWidgetIDs,
+} from '../redux/actions';
 import { Dropzone } from '../widgets/dropzone-widget/dropzone-widget';
 import { DraggableWidget } from '../widgets/draggable-widget/draggable-widget';
 import { getWidgetType, deepCloneTemplate } from './helpers';
 import { EEWidget } from '../redux/types/types';
-import { WidgetType } from '../redux/types/enums';
+import { WidgetType, EventType } from '../redux/types/enums';
 import { Panel } from '../widgets/ui-panel/ui-panel';
 import { Map } from '../widgets/ui-map/ui-map';
 import { SideMenu } from '../widgets/ui-sidemenu/ui-sidemenu';
@@ -133,4 +139,100 @@ export function getWidgetElement({
   }
 
   return { element, dropzone, map, draggable };
+}
+
+/**
+ * Retrieves previous template from localStorage and populate new template with widgets.
+ */
+export function transferData() {
+  try {
+    // Retrieve template from storage.
+    const template = localStorage.getItem('previousTemplate');
+
+    if (template) {
+      const templateJSON = JSON.parse(template);
+      const { widgets } = templateJSON;
+
+      /**
+       * Get all panels that are not the root and that exist in the new and old template.
+       * We need to retrieve panels and sidemenu widgets, because they are containers
+       * that could hold user added widgets (i.e. label, button, etc...).
+       */
+      const panelIDs = [];
+      for (const widgetID in widgets) {
+        if (
+          widgetID !== ROOT_ID &&
+          (widgetID.startsWith('panel') || widgetID.startsWith('sidemenu')) &&
+          store.getState().template.widgets.hasOwnProperty(widgetID)
+        ) {
+          panelIDs.push(widgetID);
+        }
+      }
+
+      /**
+       * Populating store with widgets that share the same IDs.
+       */
+      for (const panelID of panelIDs) {
+        const { children } = widgets[panelID];
+        for (const child of children) {
+          const childMetaData: WidgetMetaData = widgets[child];
+          const { id, uniqueAttributes, style } = childMetaData;
+
+          // Create DOM element using meta data. Returns EEWidget (i.e. <ui-label></ui-label>).
+          const { element } = getWidgetElement(childMetaData);
+
+          store.dispatch(
+            addWidgetMetaData(id, element, uniqueAttributes, style)
+          );
+
+          store.dispatch(
+            updateWidgetChildren(panelID, [
+              ...store.getState().template.widgets[panelID].children,
+              id,
+            ])
+          );
+        }
+      }
+
+      store.dispatch(setEventType(EventType.CHANGINGTEMPLATE, true));
+    }
+  } catch (e) {
+    throw e;
+  }
+}
+
+/**
+ * Updates widget ids. Since we pre-populate the template by widgets from the previous template,
+ * we need to increment the widget IDs in our store to match the new widgets.
+ */
+export function incrementWidgetIDs(widgets: { [key: string]: WidgetMetaData }) {
+  const updatedIDs: AppCreatorStore['widgetIDs'] = {};
+  for (const key in store.getState().widgetIDs) {
+    let largest = -Infinity;
+
+    for (const widgetID in widgets) {
+      const type = getWidgetType(widgetID);
+      if (type === key) {
+        try {
+          const index = widgetID.lastIndexOf('-');
+          if (index === -1) {
+            throw new Error('Widget id incorrectly formatted');
+          }
+          const count = widgetID.slice(index + 1);
+          const countInt = parseInt(count);
+          largest = Math.max(largest, countInt);
+        } catch (e) {
+          console.error(e);
+        }
+      }
+    }
+
+    if (largest !== -Infinity) {
+      updatedIDs[key] = largest + 1;
+    }
+  }
+
+  store.dispatch(updateWidgetIDs(updatedIDs));
+
+  return updatedIDs;
 }

--- a/app-creator/client/src/utils/test/helpers_test.ts
+++ b/app-creator/client/src/utils/test/helpers_test.ts
@@ -99,7 +99,7 @@ suite('util helpers', () => {
   });
 });
 
-function createTemplateStub(): AppCreatorStore['template'] {
+export function createTemplateStub(): AppCreatorStore['template'] {
   return {
     widgets: {
       'panel-0': {

--- a/app-creator/client/src/widgets/actions-panel/actions-panel.ts
+++ b/app-creator/client/src/widgets/actions-panel/actions-panel.ts
@@ -69,14 +69,14 @@ export class ActionsPanel extends connect(store)(LitElement) {
   @property({ type: Number })
   selectedTab = Tab.TEMPLATES;
 
-  handleTabSwitch(index: Tab) {
+  private handleTabSwitch(index: Tab) {
     store.dispatch(setSelectedTab(index));
   }
 
   /**
    * Collapses/Expands the actions panel.
    */
-  togglePanel({ target }: { target: EventTarget }) {
+  private togglePanel({ target }: { target: EventTarget }) {
     const panel = this.shadowRoot?.getElementById('container');
 
     if (panel == null) {

--- a/app-creator/client/src/widgets/attributes-tab/attributes-tab.ts
+++ b/app-creator/client/src/widgets/attributes-tab/attributes-tab.ts
@@ -192,7 +192,7 @@ export class AttributesTab extends connect(store)(LitElement) {
       ? store.getState().editingElement
       : null;
 
-  openTooltipBy(e: Event, key: string) {
+  private openTooltipBy(e: Event, key: string) {
     const tooltip = this.shadowRoot?.getElementById(
       key + '-tooltip'
     ) as PaperDialogElement;
@@ -202,7 +202,7 @@ export class AttributesTab extends connect(store)(LitElement) {
     }
   }
 
-  getInputHeader(key: string, title: string, tooltip?: Tooltip) {
+  private getInputHeader(key: string, title: string, tooltip?: Tooltip) {
     const tooltipMarkup =
       tooltip == null
         ? nothing
@@ -238,7 +238,7 @@ export class AttributesTab extends connect(store)(LitElement) {
     `;
   }
 
-  handleInputKeyup(
+  private handleInputKeyup(
     e: Event,
     dispatcher: (value: string) => void,
     validator?: AttributeMetaData['key']['validator']
@@ -258,7 +258,7 @@ export class AttributesTab extends connect(store)(LitElement) {
     }
   }
 
-  getTextInput(
+  private getTextInput(
     key: string,
     title: string,
     value: string,
@@ -290,7 +290,7 @@ export class AttributesTab extends connect(store)(LitElement) {
     `;
   }
 
-  handleTextAreaKeyup(
+  private handleTextAreaKeyup(
     e: Event,
     dispatcher: (value: string) => void,
     validator?: Function
@@ -308,7 +308,7 @@ export class AttributesTab extends connect(store)(LitElement) {
     }
   }
 
-  getTextareaInput(
+  private getTextareaInput(
     key: string,
     title: string,
     value: string,
@@ -342,7 +342,7 @@ ${value}</textarea
     `;
   }
 
-  getColorInput(
+  private getColorInput(
     key: string,
     title: string,
     value: string,
@@ -378,7 +378,7 @@ ${value}</textarea
     `;
   }
 
-  getSelectInput(
+  private getSelectInput(
     key: string,
     title: string,
     value: string,
@@ -420,7 +420,7 @@ ${value}</textarea
     `;
   }
 
-  getNumberInput(
+  private getNumberInput(
     key: string,
     title: string,
     value: string,
@@ -494,7 +494,7 @@ ${value}</textarea
     `;
   }
 
-  getUniqueAttributeMarkup(
+  private getUniqueAttributeMarkup(
     attributesArray: AttributeMetaData,
     uniqueAttributes: UniqueAttributes,
     id: string
@@ -576,7 +576,7 @@ ${value}</textarea
     });
   }
 
-  getUniqueAttributes(): Array<TemplateResult | {}> | {} {
+  private getUniqueAttributes(): Array<TemplateResult | {}> | {} {
     const widget = this.editingWidget;
     if (widget == null) {
       return nothing;
@@ -641,7 +641,7 @@ ${value}</textarea
     }
   }
 
-  getStyleAttributes(): Array<TemplateResult | {}> | {} {
+  private getStyleAttributes(): Array<TemplateResult | {}> | {} {
     const widget = this.editingWidget;
     if (widget == null) {
       return nothing;

--- a/app-creator/client/src/widgets/attributes-tab/attributes-tab.ts
+++ b/app-creator/client/src/widgets/attributes-tab/attributes-tab.ts
@@ -12,8 +12,6 @@ import {
   UniqueAttributes,
   Tooltip,
 } from '../../redux/types/attributes.js';
-import '@polymer/paper-dialog/paper-dialog.js';
-import '../empty-notice/empty-notice';
 import { camelCaseToTitleCase, getWidgetType } from '../../utils/helpers.js';
 import { updateWidgetMetaData } from '../../redux/actions.js';
 import {
@@ -33,6 +31,8 @@ import { Map } from '../ui-map/ui-map.js';
 import { store } from '../../redux/store';
 import { AppCreatorStore } from '../../redux/reducer';
 import { PaperDialogElement } from '@polymer/paper-dialog/paper-dialog.js';
+import '@polymer/paper-dialog/paper-dialog.js';
+import '../empty-notice/empty-notice';
 
 @customElement('attributes-tab')
 export class AttributesTab extends connect(store)(LitElement) {

--- a/app-creator/client/src/widgets/draggable-widget/draggable-widget.ts
+++ b/app-creator/client/src/widgets/draggable-widget/draggable-widget.ts
@@ -163,7 +163,7 @@ export class DraggableWidget extends LitElement {
    * Triggered when the edit icon is clicked. Stores a reference of the selected element in the store and
    * displays a set of inputs for editing its attributes.
    */
-  handleEditWidget(e: Event) {
+  private handleEditWidget(e: Event) {
     e.stopPropagation();
     if (!this.editable) {
       /**
@@ -193,7 +193,7 @@ export class DraggableWidget extends LitElement {
    * Returns the widget inside the draggable wrapper.
    * @param target draggable wrapper element.
    */
-  extractChildWidget(target: HTMLElement): Element | undefined {
+  private extractChildWidget(target: HTMLElement): Element | undefined {
     // We want to unwrap the draggable wrapper and only reference the the inner element.
     return target.querySelector('slot')?.assignedElements()[0];
   }
@@ -201,7 +201,7 @@ export class DraggableWidget extends LitElement {
   /**
    * Triggered when the trash icon is clicked.
    */
-  handleRemoveWidget(e: Event) {
+  private handleRemoveWidget(e: Event) {
     e.stopPropagation();
     const container = this.shadowRoot?.getElementById(
       CONTAINER_ID
@@ -231,7 +231,7 @@ export class DraggableWidget extends LitElement {
    * dragged element in a global state.
    * @param e dragstart event
    */
-  handleDragstart(e: Event) {
+  private handleDragstart(e: Event) {
     const target = e.target as DraggableWidget;
     if (target == null) {
       return;
@@ -254,7 +254,7 @@ export class DraggableWidget extends LitElement {
    * in a dropzone.
    * @param e dragend event
    */
-  handleDragend() {
+  private handleDragend() {
     const addedElement =
       store.getState().eventType === EventType.ADDING
         ? store.getState().draggingElement

--- a/app-creator/client/src/widgets/dropzone-widget/dropzone-widget.ts
+++ b/app-creator/client/src/widgets/dropzone-widget/dropzone-widget.ts
@@ -85,7 +85,7 @@ export class Dropzone extends LitElement {
   /**
    * Return children IDs for a given dropzone.
    */
-  getChildrenIds(): string[] {
+  private getChildrenIds(): string[] {
     return Array.from(this.children).map((el) => {
       return el.firstElementChild!.id;
     });
@@ -94,7 +94,7 @@ export class Dropzone extends LitElement {
   /**
    * Places the dragging widget in the correct order in the container.
    */
-  handleReorderingWidget(
+  private handleReorderingWidget(
     parent: Element | null,
     widget: Element,
     nextElement: Element | null
@@ -121,7 +121,7 @@ export class Dropzone extends LitElement {
   /**
    * Places a clone of the dragging widget in the correct order in the container.
    */
-  handleAddingWidget(
+  private handleAddingWidget(
     parent: Element | null,
     widget: Element,
     nextElement: Element | null
@@ -182,7 +182,7 @@ export class Dropzone extends LitElement {
   /**
    * Callback triggered whenever we drag a widget over a dropzone-widget.
    */
-  handleDragOver(e: DragEvent) {
+  private handleDragOver(e: DragEvent) {
     // Get widget that's currently being dragged.
     const widget = store.getState().draggingElement;
 
@@ -216,7 +216,7 @@ export class Dropzone extends LitElement {
    * Takes in a cloned element and returns that element with a draggable wrapper around it.
    * @param clone element to be wrapped.
    */
-  wrapDraggableWidget(clone: HTMLElement): DraggableWidget {
+  private wrapDraggableWidget(clone: HTMLElement): DraggableWidget {
     const cloneDraggableWrapper = document.createElement('draggable-widget');
     cloneDraggableWrapper.editable = true;
     cloneDraggableWrapper.style.width = '100%';
@@ -230,7 +230,7 @@ export class Dropzone extends LitElement {
    * @param widget widget currently being dragged.
    * @param y the y coordinate of the triggered event.
    */
-  getNextElement(widget: Element, y: number): Element | null {
+  private getNextElement(widget: Element, y: number): Element | null {
     /**
      * Get all widgets in the container excluding the currently dragged widget.
      * The direct children of the container are the widget wrappers that allow them to be

--- a/app-creator/client/src/widgets/palette-picker/palette-picker.ts
+++ b/app-creator/client/src/widgets/palette-picker/palette-picker.ts
@@ -106,7 +106,7 @@ export class PalettePicker extends LitElement {
   /**
    * Callback triggered on new palette selection.
    */
-  handlePaletteSelection(e: Event) {
+  private handlePaletteSelection(e: Event) {
     const newPalette = (e.target as HTMLSelectElement).value as PaletteNames;
     this.selectedPalette = newPalette;
 

--- a/app-creator/client/src/widgets/story-board/story-board.ts
+++ b/app-creator/client/src/widgets/story-board/story-board.ts
@@ -16,10 +16,7 @@ import { DeviceType, EventType, PaletteNames } from '../../redux/types/enums';
 import { store } from '../../redux/store';
 import { AppCreatorStore } from '../../redux/reducer';
 import { PaperCardElement } from '@polymer/paper-card/paper-card.js';
-import {
-  generateUI,
-  incrementWidgetIDs,
-} from '../../utils/template-generation';
+import { generateUI } from '../../utils/template-generation';
 import {
   setSelectedTemplateID,
   setEventType,
@@ -198,19 +195,6 @@ export class Storyboard extends connect(store)(LitElement) {
       store.dispatch(setEventType(EventType.NONE, true));
 
       this.renderNewTemplate(template);
-
-      try {
-        const template = localStorage.getItem('previousTemplate');
-        if (template) {
-          const widgets = JSON.parse(template).widgets;
-          incrementWidgetIDs(widgets);
-        }
-
-        localStorage.removeItem('previousTemplate');
-      } catch (e) {
-        console.error(e);
-        this.localStorageFailureToast.open();
-      }
     }
   }
 

--- a/app-creator/client/src/widgets/template-wizard/template-wizard.ts
+++ b/app-creator/client/src/widgets/template-wizard/template-wizard.ts
@@ -400,6 +400,11 @@ export class TemplateWizard extends LitElement {
     }
   }
 
+  /*
+   * TODO: Add elements to differentiate duplication flow from regular flow.
+   * Examples: populate text input with 'Copy of <previous-template>', or skip template wizard and go
+   * straight to app creation.
+   */
   render() {
     const {
       handleSearch,

--- a/app-creator/client/src/widgets/template-wizard/template-wizard.ts
+++ b/app-creator/client/src/widgets/template-wizard/template-wizard.ts
@@ -20,6 +20,7 @@ import { onSearchEvent } from '../search-bar/search-bar';
 import { generateRandomId } from '../../utils/helpers';
 import { store } from '../../redux/store';
 import { setSelectedTemplate, setPalette } from '../../redux/actions';
+import { transferData } from '../../utils/template-generation';
 import '@polymer/paper-progress/paper-progress';
 import '@cwmr/paper-chip/paper-chip.js';
 
@@ -271,21 +272,21 @@ export class TemplateWizard extends LitElement {
     this.showTemplateSelectionModal();
   }
 
-  showTemplateSelectionModal() {
+  private showTemplateSelectionModal() {
     this.dialog.open();
   }
 
   /**
    * Used for filtering templates.
    */
-  handleDeviceFilters(device: DeviceType) {
+  private handleDeviceFilters(device: DeviceType) {
     this.deviceFilter = device;
   }
 
   /**
    * Generates an input header for each setting input.
    */
-  createInputHeader(title: string) {
+  private createInputHeader(title: string) {
     return html`
       <div class="input-header">
         <p class="input-label">${title}</p>
@@ -296,14 +297,14 @@ export class TemplateWizard extends LitElement {
   /**
    * Sets currently selected template id.
    */
-  handleTemplateSelection(id: string) {
+  private handleTemplateSelection(id: string) {
     this.selectedTemplateID = id;
   }
 
   /**
    * Returns an array of template cards.
    */
-  getTemplateCards(showTitle = false): Array<TemplatesTabItem> {
+  private getTemplateCards(showTitle = false): Array<TemplatesTabItem> {
     return this.templates.map(({ id, name, imageUrl, device }) => {
       return {
         id,
@@ -328,14 +329,14 @@ export class TemplateWizard extends LitElement {
    * Sets the query property when an onsearch event is dispatched from the
    * searchbar widget.
    */
-  handleSearch({ detail: { query } }: onSearchEvent) {
+  private handleSearch({ detail: { query } }: onSearchEvent) {
     this.query = query.trim();
   }
 
   /**
    * Creates a text input element.
    */
-  createTextInput(
+  private createTextInput(
     title: string,
     value: string,
     placeholder: string,
@@ -362,45 +363,9 @@ export class TemplateWizard extends LitElement {
   }
 
   /**
-   * Creates a select input element.
-   */
-  createSelectInput(
-    key: string,
-    title: string,
-    value: string,
-    items: string[]
-  ): TemplateResult | {} {
-    if (items == null) {
-      return nothing;
-    }
-    const optionList = [];
-    for (const item of items) {
-      optionList.push(html`<option value="${item}" ?selected=${item === value}
-        >${item}</option
-      >`);
-    }
-
-    return html`
-      <div class="config-input-container config-select-input">
-        ${this.createInputHeader(title)}
-        <select
-          name="${title}"
-          class="config-input"
-          .value="${this.config[key]}"
-          @change=${(e: Event) => {
-            this.config[key] = (e.target as HTMLSelectElement).value;
-          }}
-        >
-          ${optionList}
-        </select>
-      </div>
-    `;
-  }
-
-  /**
    * Callback triggered on continue button click.
    */
-  handleContinueClick() {
+  private handleContinueClick() {
     try {
       // Get template from database.
       const template = templatesManager
@@ -418,6 +383,9 @@ export class TemplateWizard extends LitElement {
 
         // Set new template in store.
         store.dispatch(setSelectedTemplate(templateJSON));
+
+        // Populate template with widgets from localStorage.
+        transferData();
 
         // Close dialog.
         const { dialog } = this;

--- a/app-creator/client/src/widgets/templates-tab/templates-tab.ts
+++ b/app-creator/client/src/widgets/templates-tab/templates-tab.ts
@@ -18,7 +18,7 @@ import { connect } from 'pwa-helpers';
 import { AppCreatorStore } from '../../redux/reducer';
 import { DeviceType } from '../../redux/types/enums';
 import { classMap } from 'lit-html/directives/class-map';
-import { chips, storeTemplateInLocalStorage } from '../../utils/helpers';
+import { chips, storeSnapshotInLocalStorage } from '../../utils/helpers';
 import { transferData } from '../../utils/template-generation';
 import { PaperDialogElement } from '@polymer/paper-dialog';
 import '@polymer/paper-input/paper-input.js';
@@ -184,7 +184,7 @@ export class TemplatesTab extends connect(store)(LitElement) {
 
     if (template) {
       try {
-        storeTemplateInLocalStorage();
+        storeSnapshotInLocalStorage();
 
         // Replace the redux store with the new template and trigger a re-render.
         const templateJSON = JSON.parse(template);

--- a/app-creator/client/src/widgets/templates-tab/templates-tab.ts
+++ b/app-creator/client/src/widgets/templates-tab/templates-tab.ts
@@ -18,7 +18,11 @@ import { connect } from 'pwa-helpers';
 import { AppCreatorStore } from '../../redux/reducer';
 import { DeviceType } from '../../redux/types/enums';
 import { classMap } from 'lit-html/directives/class-map';
-import { chips, storeSnapshotInLocalStorage } from '../../utils/helpers';
+import {
+  chips,
+  storeSnapshotInLocalStorage,
+  setUrlParam,
+} from '../../utils/helpers';
 import { transferData } from '../../utils/template-generation';
 import { PaperDialogElement } from '@polymer/paper-dialog';
 import '@polymer/paper-input/paper-input.js';
@@ -37,6 +41,7 @@ import '../search-bar/search-bar';
 import '../empty-notice/empty-notice';
 import '../template-card/template-card';
 import '@cwmr/paper-chip/paper-chip.js';
+import { TEMPLATE_TIMESTAMP } from '../../utils/constants';
 
 export interface TemplatesTabItem {
   id: string;
@@ -184,10 +189,15 @@ export class TemplatesTab extends connect(store)(LitElement) {
 
     if (template) {
       try {
-        storeSnapshotInLocalStorage();
+        const timestamp = Date.now();
+
+        setUrlParam(TEMPLATE_TIMESTAMP, timestamp.toString());
+
+        storeSnapshotInLocalStorage(timestamp);
 
         // Replace the redux store with the new template and trigger a re-render.
         const templateJSON = JSON.parse(template);
+
         store.dispatch(setSelectedTemplate(templateJSON));
 
         transferData();

--- a/app-creator/client/src/widgets/templates-tab/templates-tab.ts
+++ b/app-creator/client/src/widgets/templates-tab/templates-tab.ts
@@ -1,7 +1,14 @@
 /**
  *  @fileoverview The templates-tab widget contains the different templates that the user can use for their earth engine app.
  */
-import { LitElement, html, customElement, css, property } from 'lit-element';
+import {
+  LitElement,
+  html,
+  customElement,
+  css,
+  property,
+  query,
+} from 'lit-element';
 import { nothing, TemplateResult } from 'lit-html';
 import { onSearchEvent } from '../search-bar/search-bar';
 import { store } from '../../redux/store';
@@ -11,7 +18,9 @@ import { connect } from 'pwa-helpers';
 import { AppCreatorStore } from '../../redux/reducer';
 import { DeviceType } from '../../redux/types/enums';
 import { classMap } from 'lit-html/directives/class-map';
-import { chips } from '../../utils/helpers';
+import { chips, storeTemplateInLocalStorage } from '../../utils/helpers';
+import { transferData } from '../../utils/template-generation';
+import { PaperDialogElement } from '@polymer/paper-dialog';
 import '@polymer/paper-input/paper-input.js';
 import '@polymer/iron-icon/iron-icon.js';
 import '../tab-container/tab-container';
@@ -39,6 +48,21 @@ export interface TemplatesTabItem {
 @customElement('templates-tab')
 export class TemplatesTab extends connect(store)(LitElement) {
   static styles = css`
+    paper-chip {
+      margin: 0px var(--extra-tight);
+      background-color: var(--primary-color);
+      color: var(--accent-color);
+    }
+
+    paper-button {
+      color: var(--accent-color);
+    }
+
+    .selected-paper-chip {
+      background-color: var(--accent-color);
+      color: var(--primary-color);
+    }
+
     .subtitle {
       margin: var(--regular) 0px var(--tight) 0px;
       color: var(--accent-color);
@@ -56,29 +80,20 @@ export class TemplatesTab extends connect(store)(LitElement) {
       margin-top: var(--tight);
     }
 
-    paper-chip {
-      margin: 0px var(--extra-tight);
-      background-color: var(--primary-color);
-      color: var(--accent-color);
-    }
-
-    .selected-paper-chip {
-      background-color: var(--accent-color);
-      color: var(--primary-color);
+    #template-change-confirmation-dialog {
+      border-radius: var(--tight);
     }
   `;
-
-  stateChanged(state: AppCreatorStore) {
-    if (state.template.config.parentID !== this.selectedTemplateID) {
-      this.selectedTemplateID = state.template.config.parentID;
-      this.requestUpdate();
-    }
-  }
 
   /**
    * Represents the id of the currently selected template. Used to rerender templates tab.
    */
   @property({ type: String }) selectedTemplateID: string = '';
+
+  /**
+   * ID of template to be selected.
+   */
+  @property({ type: String }) requestedTemplateID: string = '';
 
   /**
    * Sets the search query.
@@ -90,9 +105,22 @@ export class TemplatesTab extends connect(store)(LitElement) {
    */
   @property({ type: String }) deviceFilter = DeviceType.ALL;
 
-  getTemplateCards(showTitle = false) {
+  /**
+   * Reference to template change confirmation dialog.
+   */
+  @query('#template-change-confirmation-dialog')
+  templateChangeConfirmationDialog!: PaperDialogElement;
+
+  stateChanged(state: AppCreatorStore) {
+    if (state.template.config.parentID !== this.selectedTemplateID) {
+      this.selectedTemplateID = state.template.config.parentID;
+      this.requestUpdate();
+    }
+  }
+
+  private getTemplateCards(showTitle = false) {
     const templates = templatesManager.getTemplates();
-    return templates.map(({ id, name, imageUrl, device, template }) => {
+    return templates.map(({ id, name, imageUrl, device }) => {
       return {
         id,
         name,
@@ -105,7 +133,7 @@ export class TemplatesTab extends connect(store)(LitElement) {
             imageUrl="${imageUrl}"
             ?showTitle=${showTitle}
             ?selected=${store.getState().template.config.parentID === id}
-            .onSelection=${this.createSelectionCallback(template)}
+            .onSelection=${this.handleTemplateCardSelection(id)}
           ></template-card>
         `,
       };
@@ -134,23 +162,59 @@ export class TemplatesTab extends connect(store)(LitElement) {
     });
   }
 
-  createSelectionCallback(template: string): VoidFunction {
+  /**
+   * Callback triggered on template card selection.
+   */
+  private handleTemplateCardSelection(id: string) {
     return () => {
-      store.dispatch(setSelectedTemplate(JSON.parse(template)));
-      this.requestUpdate();
+      this.requestedTemplateID = id;
+      if (this.templateChangeConfirmationDialog) {
+        this.templateChangeConfirmationDialog.open();
+      }
     };
+  }
+
+  /**
+   * Callback triggered on template change confirmation.
+   */
+  private handleTemplateChangeConfirmation() {
+    const template = templatesManager
+      .getTemplates()
+      .find(({ id }) => id === this.requestedTemplateID)?.template;
+
+    if (template) {
+      try {
+        storeTemplateInLocalStorage();
+
+        // Replace the redux store with the new template and trigger a re-render.
+        const templateJSON = JSON.parse(template);
+        store.dispatch(setSelectedTemplate(templateJSON));
+
+        transferData();
+      } catch (e) {
+        console.error(e);
+      }
+    }
+
+    this.templateChangeConfirmationDialog.close();
+
+    this.requestUpdate();
+  }
+
+  /**
+   * Callback triggered on template change dismiss.
+   */
+  private handleTemplateChangeDismiss() {
+    this.requestedTemplateID = '';
+    this.templateChangeConfirmationDialog.close();
   }
 
   /**
    * Sets the query property when an onsearch event is dispatched from the
    * searchbar widget.
    */
-  handleSearch({ detail: { query } }: onSearchEvent) {
+  private handleSearch({ detail: { query } }: onSearchEvent) {
     this.query = query.trim();
-  }
-
-  handleDeviceFilters(device: DeviceType) {
-    this.deviceFilter = device;
   }
 
   render() {
@@ -193,6 +257,25 @@ export class TemplatesTab extends connect(store)(LitElement) {
       </div>
     `;
 
+    const templateChangeConfirmationDialog = html`
+      <paper-dialog with-backdrop id="template-change-confirmation-dialog">
+        <h2>Are you sure?</h2>
+        <p>
+          Changing templates will discard any applied styles or layouts.
+        </p>
+        <div class="buttons">
+          <paper-button @click=${this.handleTemplateChangeDismiss}
+            >Decline</paper-button
+          >
+          <paper-button
+            @click=${this.handleTemplateChangeConfirmation}
+            autofocus
+            >Accept</paper-button
+          >
+        </div>
+      </paper-dialog>
+    `;
+
     return html`
       <tab-container title="Templates">
         <search-bar
@@ -204,6 +287,7 @@ export class TemplatesTab extends connect(store)(LitElement) {
           ${filteredTemplates.map(({ markup }) => markup)}
           ${filteredTemplates.length === 0 ? emptyNotice : nothing}
         </div>
+        ${templateChangeConfirmationDialog}
       </tab-container>
     `;
   }

--- a/app-creator/client/src/widgets/tool-bar/tool-bar.ts
+++ b/app-creator/client/src/widgets/tool-bar/tool-bar.ts
@@ -12,7 +12,7 @@ import { setSelectedTemplate } from '../../redux/actions';
 import { PaperToastElement } from '@polymer/paper-toast/paper-toast.js';
 import {
   deepCloneTemplate,
-  storeTemplateInLocalStorage,
+  storeSnapshotInLocalStorage,
   createToastMessage,
 } from '../../utils/helpers';
 import { incrementWidgetIDs } from '../../utils/template-generation';
@@ -250,11 +250,18 @@ export class ToolBar extends LitElement {
    */
   private handleDuplicateButtonAction() {
     try {
-      storeTemplateInLocalStorage();
+      /**
+       * Get current timestamp to store it as a key.
+       */
+      const timestamp = Date.now();
 
-      const url = location.href;
+      storeSnapshotInLocalStorage(timestamp);
 
-      window.open(url);
+      const url = new URL(location.href);
+
+      url.searchParams.set('template_timestamp', timestamp.toString());
+
+      window.open(url.href);
     } catch (e) {
       this.localStorageFailureToast.open();
     }

--- a/app-creator/client/src/widgets/tool-bar/tool-bar.ts
+++ b/app-creator/client/src/widgets/tool-bar/tool-bar.ts
@@ -10,7 +10,12 @@ import { PaperDialogElement } from '@polymer/paper-dialog/paper-dialog.js';
 import { ROOT_ID } from '../../utils/constants';
 import { setSelectedTemplate } from '../../redux/actions';
 import { PaperToastElement } from '@polymer/paper-toast/paper-toast.js';
-import { deepCloneTemplate } from '../../utils/helpers';
+import {
+  deepCloneTemplate,
+  storeTemplateInLocalStorage,
+  createToastMessage,
+} from '../../utils/helpers';
+import { incrementWidgetIDs } from '../../utils/template-generation';
 import '@polymer/paper-button/paper-button.js';
 import '@polymer/paper-dialog/paper-dialog.js';
 import '@polymer/paper-dialog-scrollable/paper-dialog-scrollable.js';
@@ -123,10 +128,21 @@ export class ToolBar extends LitElement {
   @query('#import-textarea') importTextArea!: HTMLTextAreaElement;
 
   /**
+   * Reference to invalid JSON toast widget.
+   */
+  @query('#invalid-json-toast') invalidJSONToast!: PaperToastElement;
+
+  /**
+   * Reference to local storage failure toast widget.
+   */
+  @query('#failed-local-storage-toast')
+  localStorageFailureToast!: PaperToastElement;
+
+  /**
    * Triggered when export button is clicked. It displays the paper dialog which
    * contains the serialized template string.
    */
-  openExportDialog() {
+  private openExportDialog() {
     const jsonSnippetContainer = this.shadowRoot?.getElementById(
       'json-snippet'
     );
@@ -144,7 +160,7 @@ export class ToolBar extends LitElement {
    * Triggered when import button is clicked. It displays the paper dialog which
    * allows users to paste a template string.
    */
-  openImportDialog() {
+  private openImportDialog() {
     if (this.importDialog == null) {
       return;
     }
@@ -155,7 +171,7 @@ export class ToolBar extends LitElement {
   /**
    * Returns the serialized template string with indentation.
    */
-  getTemplateString(space: number = 0) {
+  private getTemplateString(space: number = 0) {
     const template = deepCloneTemplate(store.getState().template);
     return JSON.stringify(template, null, space);
   }
@@ -163,7 +179,7 @@ export class ToolBar extends LitElement {
   /**
    * Adds template string to clipboard.
    */
-  copy() {
+  private copy() {
     const textArea = document.createElement('textarea');
     // We get the template string without indentation and with escaped single quotes.
     textArea.value = this.getTemplateString().replace(/'/g, "\\'");
@@ -176,7 +192,7 @@ export class ToolBar extends LitElement {
   /**
    * Imports template from JSON provided by the user.
    */
-  importTemplate() {
+  private importTemplate() {
     // Get textarea input element.
     if (this.importTextArea == null) {
       return;
@@ -206,22 +222,18 @@ export class ToolBar extends LitElement {
       // Update the store with the new template.
       store.dispatch(setSelectedTemplate(templateJSON));
 
+      incrementWidgetIDs(templateJSON.widgets);
+
       this.importDialog.close();
 
       this.clearTextArea('import-textarea');
     } catch (e) {
-      const fetchErrorToast = this.shadowRoot?.getElementById(
-        'invalid-json-toast'
-      ) as PaperToastElement;
-
-      if (fetchErrorToast != null) {
-        fetchErrorToast.open();
-      }
+      this.invalidJSONToast.open();
     }
   }
 
   // Empties text area input.
-  clearTextArea(id: string) {
+  private clearTextArea(id: string) {
     const textarea = this.shadowRoot?.querySelector(
       `#${id}`
     ) as HTMLTextAreaElement;
@@ -233,12 +245,28 @@ export class ToolBar extends LitElement {
     textarea.value = '';
   }
 
+  /**
+   * Callback triggered when duplicate button is clicked.
+   */
+  private handleDuplicateButtonAction() {
+    try {
+      storeTemplateInLocalStorage();
+
+      const url = location.href;
+
+      window.open(url);
+    } catch (e) {
+      this.localStorageFailureToast.open();
+    }
+  }
+
   render() {
     const {
       openExportDialog,
       openImportDialog,
       importTemplate,
       clearTextArea,
+      handleDuplicateButtonAction,
       copy,
     } = this;
 
@@ -288,6 +316,16 @@ export class ToolBar extends LitElement {
       </paper-dialog>
     `;
 
+    const invalidJSONToast = createToastMessage(
+      'invalid-json-toast',
+      'Failed to duplicate template.'
+    );
+
+    const localStorageFailureToast = createToastMessage(
+      'failed-local-storage-toast',
+      'Failed to duplicate template.'
+    );
+
     return html`
       <div id="container">
         <h3>
@@ -296,6 +334,9 @@ export class ToolBar extends LitElement {
         </h3>
 
         <div>
+          <paper-button id="import-button" @click=${handleDuplicateButtonAction}
+            >Duplicate</paper-button
+          >
           <paper-button id="import-button" @click=${openImportDialog}
             >Import</paper-button
           >
@@ -304,11 +345,8 @@ export class ToolBar extends LitElement {
           >
         </div>
 
-        ${importDialog} ${exportDialog}
-        <paper-toast
-          id="invalid-json-toast"
-          text="Invalid template string."
-        ></paper-toast>
+        ${importDialog} ${exportDialog} ${invalidJSONToast}
+        ${localStorageFailureToast}
       </div>
     `;
   }

--- a/app-creator/client/src/widgets/tool-bar/tool-bar.ts
+++ b/app-creator/client/src/widgets/tool-bar/tool-bar.ts
@@ -7,13 +7,14 @@
 import { LitElement, html, customElement, css, query } from 'lit-element';
 import { store } from '../../redux/store';
 import { PaperDialogElement } from '@polymer/paper-dialog/paper-dialog.js';
-import { ROOT_ID } from '../../utils/constants';
+import { ROOT_ID, TEMPLATE_TIMESTAMP } from '../../utils/constants';
 import { setSelectedTemplate } from '../../redux/actions';
 import { PaperToastElement } from '@polymer/paper-toast/paper-toast.js';
 import {
   deepCloneTemplate,
   storeSnapshotInLocalStorage,
   createToastMessage,
+  setUrlParam,
 } from '../../utils/helpers';
 import { incrementWidgetIDs } from '../../utils/template-generation';
 import '@polymer/paper-button/paper-button.js';
@@ -257,9 +258,7 @@ export class ToolBar extends LitElement {
 
       storeSnapshotInLocalStorage(timestamp);
 
-      const url = new URL(location.href);
-
-      url.searchParams.set('template_timestamp', timestamp.toString());
+      const url = setUrlParam(TEMPLATE_TIMESTAMP, timestamp.toString());
 
       window.open(url.href);
     } catch (e) {

--- a/app-creator/client/src/widgets/ui-map/ui-map.ts
+++ b/app-creator/client/src/widgets/ui-map/ui-map.ts
@@ -204,7 +204,7 @@ export class Map extends LitElement {
     this.onclick = (e: Event) => e.stopPropagation();
   }
 
-  handleMouseDown(e: Event) {
+  private handleMouseDown(e: Event) {
     e.stopPropagation();
     DraggableWidget.removeEditingWidgetHighlight();
     if (store.getState().editingElement != this) {
@@ -217,7 +217,7 @@ export class Map extends LitElement {
    * Called on initialization and on property changes. Initial call
    * creates a new map instance but subsequent ones update the existing object.
    */
-  updateMap() {
+  private updateMap() {
     loadGoogleMaps(this.apiKey).then(() => {
       this.mapOptions.zoom = this.zoom || 0;
 
@@ -305,7 +305,7 @@ export class Map extends LitElement {
     this.updateMap();
   }
 
-  getCustomMapStyle(value: string): google.maps.MapTypeStyle[] {
+  private getCustomMapStyle(value: string): google.maps.MapTypeStyle[] {
     switch (value) {
       case 'standard':
         return standard;

--- a/app-creator/client/src/widgets/ui-sidemenu/ui-sidemenu.ts
+++ b/app-creator/client/src/widgets/ui-sidemenu/ui-sidemenu.ts
@@ -28,6 +28,7 @@ export class SideMenu extends LitElement {
       margin: var(--tight);
       pointer-events: auto;
       background-color: white;
+      color: #000000;
       border-radius: 50%;
       z-index: 10;
     }

--- a/app-creator/client/src/widgets/ui-sidemenu/ui-sidemenu.ts
+++ b/app-creator/client/src/widgets/ui-sidemenu/ui-sidemenu.ts
@@ -97,7 +97,7 @@ export class SideMenu extends LitElement {
     }
   }
 
-  toggleMenu(e: Event) {
+  private toggleMenu(e: Event) {
     e.stopPropagation();
 
     const { panel } = this;
@@ -107,6 +107,7 @@ export class SideMenu extends LitElement {
 
     const isZeroWidth = panel.style.width.match(/^\s*0(px|%)?/);
     panel.style.width = isZeroWidth ? '80%' : '0%';
+    panel.style.display = isZeroWidth ? 'block' : 'none';
   }
 
   setStyle(style: { [key: string]: string }) {

--- a/app-creator/client/src/widgets/widgets-tab/widgets-tab.ts
+++ b/app-creator/client/src/widgets/widgets-tab/widgets-tab.ts
@@ -150,7 +150,7 @@ export class WidgetsTab extends LitElement {
   /**
    * Returns widgets with names and ids that include the search query.
    */
-  private filterWidgets(query: string): WidgetItem[] {
+  filterWidgets(query: string): WidgetItem[] {
     return WidgetsTab.widgets.filter(({ id, name }) => {
       const lowerCasedQuery = query.toLowerCase();
       return (

--- a/app-creator/client/src/widgets/widgets-tab/widgets-tab.ts
+++ b/app-creator/client/src/widgets/widgets-tab/widgets-tab.ts
@@ -150,7 +150,7 @@ export class WidgetsTab extends LitElement {
   /**
    * Returns widgets with names and ids that include the search query.
    */
-  filterWidgets(query: string): WidgetItem[] {
+  private filterWidgets(query: string): WidgetItem[] {
     return WidgetsTab.widgets.filter(({ id, name }) => {
       const lowerCasedQuery = query.toLowerCase();
       return (
@@ -164,7 +164,7 @@ export class WidgetsTab extends LitElement {
    * Sets the query property when an onsearch event is dispatched from the
    * searchbar widget.
    */
-  handleSearch({ detail: { query } }: onSearchEvent) {
+  private handleSearch({ detail: { query } }: onSearchEvent) {
     this.query = query;
   }
 }


### PR DESCRIPTION
## What are we adding in this PR

This PR introduces widget sharing between templates. 

Whenever we change templates, we store a snapshot of it in local storage. We then retrieve the stored version to re-populate the new template with widgets from the previous one.

We can also share widgets across browser tabs by duplicating a template and selecting a new theme. 

![capture (10)](https://user-images.githubusercontent.com/26859947/89802303-583b0500-daff-11ea-9df2-40b74604eb39.gif)