### PR TITLE
Removed paper chip dependency

### DIFF
--- a/app-creator/client/package.json
+++ b/app-creator/client/package.json
@@ -30,7 +30,6 @@
   "author": "Earth Engine Team",
   "license": "BSD-3-Clause",
   "dependencies": {
-    "@cwmr/paper-chip": "^3.0.0",
     "@polymer/iron-icons": "^3.0.1",
     "@polymer/iron-label": "^3.0.1",
     "@polymer/paper-button": "^3.0.1",

--- a/app-creator/client/src/widgets/app-root.ts
+++ b/app-creator/client/src/widgets/app-root.ts
@@ -5,7 +5,6 @@
 import { LitElement, html, customElement, css } from 'lit-element';
 import '@polymer/paper-progress/paper-progress.js';
 import '@polymer/paper-toast/paper-toast.js';
-import '@cwmr/paper-chip/paper-chip.js';
 import './tool-bar/tool-bar';
 import './actions-panel/actions-panel';
 import './tab-container/tab-container';

--- a/app-creator/client/src/widgets/template-wizard/template-wizard.ts
+++ b/app-creator/client/src/widgets/template-wizard/template-wizard.ts
@@ -84,7 +84,7 @@ export class TemplateWizard extends LitElement {
       flex-wrap: wrap;
       align-items: center;
       justify-content: center;
-      margin-top: var(--tight);
+      margin-top: var(--regular);
     }
 
     .selected-paper-chip {

--- a/app-creator/client/src/widgets/template-wizard/template-wizard.ts
+++ b/app-creator/client/src/widgets/template-wizard/template-wizard.ts
@@ -10,6 +10,7 @@ import {
   html,
 } from 'lit-element';
 import { nothing, TemplateResult } from 'lit-html';
+import { classMap } from 'lit-html/directives/class-map';
 import { DeviceType, PaletteNames } from '../../redux/types/enums';
 import { TemplateItem } from '../../client/fetch-templates';
 import { PaperDialogElement } from '@polymer/paper-dialog';
@@ -17,12 +18,11 @@ import { templatesManager } from '../../data/templates';
 import { PaperToastElement } from '@polymer/paper-toast';
 import { TemplatesTabItem, TemplatesTab } from '../templates-tab/templates-tab';
 import { onSearchEvent } from '../search-bar/search-bar';
-import { generateRandomId } from '../../utils/helpers';
+import { generateRandomId, chips } from '../../utils/helpers';
 import { store } from '../../redux/store';
 import { setSelectedTemplate, setPalette } from '../../redux/actions';
 import { transferData } from '../../utils/template-generation';
 import '@polymer/paper-progress/paper-progress';
-import '@cwmr/paper-chip/paper-chip.js';
 
 @customElement('template-wizard')
 export class TemplateWizard extends LitElement {
@@ -87,15 +87,17 @@ export class TemplateWizard extends LitElement {
       margin-top: var(--tight);
     }
 
-    paper-chip {
-      margin: 0px var(--extra-tight);
-      background-color: var(--primary-color);
-      color: var(--accent-color);
-    }
-
     .selected-paper-chip {
       background-color: var(--accent-color);
       color: var(--primary-color);
+    }
+
+    .button-chip {
+      padding: var(--tight);
+      height: 24px;
+      border-radius: 12px;
+      font-size: 0.8rem;
+      text-transform: none;
     }
 
     #content-body {
@@ -133,7 +135,7 @@ export class TemplateWizard extends LitElement {
       border-top: var(--light-border);
     }
 
-    paper-button {
+    #continue-button {
       background-color: var(--accent-color);
       color: var(--primary-color);
       height: 30px;
@@ -452,29 +454,19 @@ export class TemplateWizard extends LitElement {
 
     const sortingChips = html`
       <div id="chips-container">
-        <paper-chip
-          selectable
-          class="${this.deviceFilter === DeviceType.ALL
-            ? 'selected-paper-chip'
-            : ''}"
-          @click=${() => handleDeviceFilters.call(this, DeviceType.ALL)}
-          >All</paper-chip
-        >
-        <paper-chip
-          selectable
-          class="${this.deviceFilter === DeviceType.DESKTOP
-            ? 'selected-paper-chip'
-            : ''}"
-          @click=${() => handleDeviceFilters.call(this, DeviceType.DESKTOP)}
-          >Web</paper-chip
-        ><paper-chip
-          selectable
-          class="${this.deviceFilter === DeviceType.MOBILE
-            ? 'selected-paper-chip'
-            : ''}"
-          @click=${() => handleDeviceFilters.call(this, DeviceType.MOBILE)}
-          >Mobile</paper-chip
-        >
+        ${chips.map(({ label, device }) => {
+          return html`
+            <paper-button
+              class=${classMap({
+                'selected-paper-chip': this.deviceFilter === device,
+                'button-chip': true,
+              })}
+              @click=${() => handleDeviceFilters.call(this, device)}
+            >
+              ${label}
+            </paper-button>
+          `;
+        })}
       </div>
     `;
 
@@ -527,6 +519,7 @@ export class TemplateWizard extends LitElement {
           </div>
           <div id="button-container">
             <paper-button
+              id="continue-button"
               class="${disabledClass}"
               ?disabled=${!validForm}
               @click=${handleContinueClick}

--- a/app-creator/client/src/widgets/template-wizard/test/template-wizard_test.ts
+++ b/app-creator/client/src/widgets/template-wizard/test/template-wizard_test.ts
@@ -9,6 +9,7 @@ import {
   assert,
   elementUpdated,
 } from '@open-wc/testing';
+import { PaperButtonElement } from '@polymer/paper-button';
 
 suite('template-wizard', () => {
   test('is defined', () => {
@@ -34,8 +35,8 @@ suite('template-wizard', () => {
 
       // Find continue button.
       const continueButton = templateWizard.shadowRoot?.querySelector(
-        'paper-button'
-      );
+        '#continue-button'
+      ) as PaperButtonElement;
 
       if (!continueButton) {
         // Force fail if continue button is not found.
@@ -56,8 +57,8 @@ suite('template-wizard', () => {
 
       // Find continue button.
       const continueButton = templateWizard.shadowRoot?.querySelector(
-        'paper-button'
-      );
+        '#continue-button'
+      ) as PaperButtonElement;
 
       if (!continueButton) {
         // Force fail if continue button is not found.
@@ -78,8 +79,8 @@ suite('template-wizard', () => {
 
       // Find continue button.
       const continueButton = templateWizard.shadowRoot?.querySelector(
-        'paper-button'
-      );
+        '#continue-button'
+      ) as PaperButtonElement;
 
       if (!continueButton) {
         // Force fail if continue button is not found.
@@ -101,8 +102,8 @@ suite('template-wizard', () => {
 
       // Find continue button.
       const continueButton = templateWizard.shadowRoot?.querySelector(
-        'paper-button'
-      );
+        '#continue-button'
+      ) as PaperButtonElement;
 
       if (!continueButton) {
         // Force fail if continue button is not found.

--- a/app-creator/client/src/widgets/templates-tab/templates-tab.ts
+++ b/app-creator/client/src/widgets/templates-tab/templates-tab.ts
@@ -41,7 +41,6 @@ import '../ui-chart/ui-chart';
 import '../search-bar/search-bar';
 import '../empty-notice/empty-notice';
 import '../template-card/template-card';
-import '@cwmr/paper-chip/paper-chip.js';
 
 export interface TemplatesTabItem {
   id: string;
@@ -53,12 +52,6 @@ export interface TemplatesTabItem {
 @customElement('templates-tab')
 export class TemplatesTab extends connect(store)(LitElement) {
   static styles = css`
-    paper-chip {
-      margin: 0px var(--extra-tight);
-      background-color: var(--primary-color);
-      color: var(--accent-color);
-    }
-
     paper-button {
       color: var(--accent-color);
     }
@@ -66,6 +59,14 @@ export class TemplatesTab extends connect(store)(LitElement) {
     .selected-paper-chip {
       background-color: var(--accent-color);
       color: var(--primary-color);
+    }
+
+    .button-chip {
+      padding: var(--tight) 0px;
+      height: 24px;
+      border-radius: 12px;
+      font-size: 0.8rem;
+      text-transform: none;
     }
 
     .subtitle {
@@ -252,16 +253,17 @@ export class TemplatesTab extends connect(store)(LitElement) {
       <div id="chips-container">
         ${chips.map(({ label, device }) => {
           return html`
-            <paper-chip
-              selectable
+            <paper-button
               class=${classMap({
                 'selected-paper-chip': this.deviceFilter === device,
+                'button-chip': true,
               })}
               @click=${() => {
                 this.deviceFilter = device;
               }}
-              >${label}</paper-chip
             >
+              ${label}
+            </paper-button>
           `;
         })}
       </div>


### PR DESCRIPTION
## What are we adding in this PR?

This PR removes the `paper-chip` dependency and uses a `paper-button` widget instead. This change affects the following 2 files `templates-tab` and `template-wizard` like so.

```Typescript
    const sortingChips = html`
      <div id="chips-container">
        ${chips.map(({ label, device }) => {
          return html`
            <paper-button
              class=${classMap({
                'selected-paper-chip': this.deviceFilter === device,
                'button-chip': true,
              })}
              @click=${() => handleDeviceFilters.call(this, device)}
            >
              ${label}
            </paper-button>
          `;
        })}
      </div>
    `;
``` 

<img src="https://user-images.githubusercontent.com/26859947/91099384-337f7b00-e631-11ea-98b8-c3e1f7dbeb42.png" width="500px"/>
