### PR TITLE
Temporarily removed template fetch toast 

### DIFF
--- a/app-creator/client/src/widgets/template-wizard/template-wizard.ts
+++ b/app-creator/client/src/widgets/template-wizard/template-wizard.ts
@@ -271,12 +271,15 @@ export class TemplateWizard extends LitElement {
         this.templates = templates;
       }
     } catch (e) {
-      const fetchErrorToast = this.shadowRoot?.getElementById(
-                                  'fetch-error-toast') as PaperToastElement;
+      console.error(e);
+      // TODO: Uncomment when datastore templates do not 
+      // reflect the ones on the client.
+      // const fetchErrorToast = this.shadowRoot?.getElementById(
+      //                             'fetch-error-toast') as PaperToastElement;
 
-      if (fetchErrorToast != null) {
-        fetchErrorToast.open();
-      }
+      // if (fetchErrorToast != null) {
+      //   fetchErrorToast.open();
+      // }
       this.templates = templatesManager.getTemplates();
     } finally {
       this.loading = false;


### PR DESCRIPTION
This PR temporarily removes the fetch error toast message since we are storing the templates on the client for the time being.

An issue tracking this can be found here: https://github.com/googleinterns/earthengine-community/projects/1#card-44518664